### PR TITLE
Add freeform character notes to builder and tracker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,7 +95,12 @@ export function App() {
         {screen === 'build' ? (
           <Builder def={def} onChange={setDef} />
         ) : (
-          <Tracker def={def} session={session} onChange={setSession} />
+          <Tracker
+            def={def}
+            session={session}
+            onChange={setSession}
+            onDefChange={setDef}
+          />
         )}
       </main>
     </div>

--- a/src/components/Builder.tsx
+++ b/src/components/Builder.tsx
@@ -263,6 +263,20 @@ export function Builder({ def, onChange }: BuilderProps) {
         />
       </section>
 
+      {/* Notes ---------------------------------------------------------- */}
+      <section className="card">
+        <h2>Notes</h2>
+        <label className="field">
+          <span>Backstory, reminders, anything</span>
+          <textarea
+            rows={6}
+            value={def.notes ?? ''}
+            placeholder="Freeform notes — background story, table reminders, loose ends…"
+            onChange={(e) => update({ notes: e.target.value })}
+          />
+        </label>
+      </section>
+
       <ImportExport def={def} onChange={onChange} />
     </div>
   );

--- a/src/components/Tracker.tsx
+++ b/src/components/Tracker.tsx
@@ -20,9 +20,11 @@ interface TrackerProps {
   def: CharacterDefinition;
   session: SessionState;
   onChange: (session: SessionState) => void;
+  /** Edits the character definition. Notes are definition data, not session. */
+  onDefChange: (def: CharacterDefinition) => void;
 }
 
-export function Tracker({ def, session, onChange }: TrackerProps) {
+export function Tracker({ def, session, onChange, onDefChange }: TrackerProps) {
   const patch = (p: Partial<SessionState>) => onChange({ ...session, ...p });
 
   const activeIds = useMemo(
@@ -229,6 +231,20 @@ export function Tracker({ def, session, onChange }: TrackerProps) {
             onToggle={toggleUse}
           />
         )}
+      </section>
+
+      {/* Notes -------------------------------------------------------- */}
+      <section className="card">
+        <h2>Notes</h2>
+        <label className="field">
+          <span>Backstory, reminders, anything</span>
+          <textarea
+            rows={5}
+            value={def.notes ?? ''}
+            placeholder="Freeform notes — background story, table reminders, loose ends…"
+            onChange={(e) => onDefChange({ ...def, notes: e.target.value })}
+          />
+        </label>
       </section>
 
       {/* Resets ------------------------------------------------------- */}

--- a/src/content/schema.ts
+++ b/src/content/schema.ts
@@ -344,6 +344,12 @@ export const characterDefinitionSchema = z.object({
 
   /** Background-question answers, freeform Q→A. Rules: "Quick Backstory". */
   background: z.record(z.string(), z.string()).optional(),
+
+  /**
+   * Freeform player notes — backstory prose, table reminders, whatever. Part of
+   * the definition (travels in the share link and JSON), not session state.
+   */
+  notes: z.string().optional(),
 });
 export type CharacterDefinition = z.infer<typeof characterDefinitionSchema>;
 


### PR DESCRIPTION
## What

Adds a freeform **Notes** field to the character — for backstory prose, table reminders, loose ends, etc. It shows up (and is editable) on both the **Builder** and the **Tracker**.

## Why it's placed where it is

Notes are **character definition** data, not session state:
- They travel in the share link and JSON export automatically (serialization is whole-object).
- They're kept out of `sessionStateSchema`, so a "New scene" / "New job" reset never touches them.
- The Tracker previously only patched session state, so it gained an `onDefChange` prop to write the note back to the definition.

## Backward compatibility

The `notes` field is `optional()`. Existing share links and saved JSON have no `notes` key and still decode cleanly (`safeParse` passes, value is `undefined`, textarea renders empty). `rulesVersion` is unchanged, so this doesn't trip the version-mismatch banner. localStorage session state is untouched.

## Verification

- `tsc --noEmit` clean
- `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)