### PR TITLE
Add Vitest suite: content structure, tag resolution, serialize, resets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run lint
+      - run: npm test
       # `npm run build` is `tsc -b && vite build` — the typecheck AND the build.
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "globals": "^17.12.0",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.69.0",
-        "vite": "^6.0.3"
+        "vite": "^6.0.3",
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1440,6 +1441,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1484,6 +1492,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -1843,6 +1869,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -1905,6 +2044,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2001,6 +2150,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2106,6 +2265,13 @@
       "integrity": "sha512-aYlviXiaXBbzvKgyALpcMmqa3Np3sDr0XnZbEG62n2UpZFbEcjQ4EEMOLGzVPhwVnwTz0lvKY+GcARbunuHekw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -2340,6 +2506,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2348,6 +2524,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2722,6 +2908,16 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2776,6 +2972,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/optionator": {
@@ -2860,6 +3070,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3063,6 +3280,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3072,6 +3296,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3099,6 +3337,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -3114,6 +3369,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3296,6 +3561,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3310,6 +3665,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "lint": "eslint .",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "lz-string": "^1.5.0",
@@ -26,6 +28,7 @@
     "globals": "^17.12.0",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.69.0",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "vitest": "^4.1.11"
   }
 }

--- a/src/content/content.test.ts
+++ b/src/content/content.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { trainings, spellTagsById } from './index';
+import { trainingSchema } from './schema';
+
+/**
+ * The "structural tests" CLAUDE.md relies on to catch silent transcription
+ * failures. Training files only `satisfies Training` (compile-time), so the Zod
+ * schema is never actually run against authored content — these tests run it.
+ */
+describe('trainings', () => {
+  it('has all ten trainings', () => {
+    expect(trainings).toHaveLength(10);
+  });
+
+  it.each(trainings)(
+    '$name is structurally valid (specialty, 5 wyrd, 5 mundane, non-empty tags)',
+    (training) => {
+      // trainingSchema enforces: specialty present, exactly 5 wyrd nodes,
+      // exactly 5 mundane nodes, and a non-empty availableTagIds list.
+      expect(() => trainingSchema.parse(training)).not.toThrow();
+    },
+  );
+
+  it.each(trainings)(
+    '$name references only spell tags that resolve',
+    (training) => {
+      for (const tagId of training.availableTagIds) {
+        expect(spellTagsById.has(tagId)).toBe(true);
+      }
+    },
+  );
+});

--- a/src/lib/serialize.test.ts
+++ b/src/lib/serialize.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { encodeDefinition, decodeDefinition } from './serialize';
+import { emptyDefinition } from './character';
+import type { CharacterDefinition } from '../content/schema';
+
+/**
+ * The definition travels in the URL fragment as an LZ-compressed JSON payload.
+ * A share link is only useful if what comes back out equals what went in.
+ * encode/decode are pure (no window access), so this needs no DOM.
+ */
+describe('serialize round-trip', () => {
+  it('decodes back to an equal definition', () => {
+    const def: CharacterDefinition = {
+      ...emptyDefinition(),
+      name: 'Jitterbug Deux',
+      mainTrainingId: 'field-tinkerer',
+      startingPath: 'wyrd',
+      takenNodes: [
+        { trainingId: 'field-tinkerer', path: 'wyrd', index: 2 },
+        { trainingId: 'field-tinkerer', path: 'mundane', index: 1 },
+      ],
+      signatureTagId: 'spark',
+      signatureTune: 'fast',
+      statDice: { brains: 'd12', brawn: 'd4', charm: 'd8' },
+      trope: { id: 'custom', name: 'Homebrew Trope', text: 'Made up at the table.' },
+      strength: { id: 'nerves', name: 'Nerves of Steel', text: 'Unflappable.' },
+      flaw: { id: 'reckless', name: 'Reckless', text: 'Leaps first.' },
+      notes: 'Owes the fixer a favour.',
+    };
+
+    const roundTripped = decodeDefinition(encodeDefinition(def));
+    expect(roundTripped).toEqual(def);
+  });
+
+  it('returns null for undecodable input', () => {
+    expect(decodeDefinition('')).toBeNull();
+    // Valid-looking string that decompresses to something that isn't a definition.
+    expect(decodeDefinition('not-a-real-payload')).toBeNull();
+  });
+});

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { newScene, newJob, emptySession } from './storage';
+import { emptyDefinition, usableAbilities } from './character';
+import type { CharacterDefinition, SessionState } from '../content/schema';
+
+/**
+ * Reset semantics from CLAUDE.md: "New scene" clears per-scene uses and zeroes
+ * Wyrd; "New job" clears everything including Exposure. And the two data
+ * lifecycles stay disjoint — a reset must never touch the definition.
+ *
+ * Keys are derived from usableAbilities() rather than hard-coded so the test
+ * stays generic over content (Field Tinkerer's specialty is perJob and its
+ * first mundane node is perScene, giving us one key of each cadence).
+ */
+function fixture(): {
+  def: CharacterDefinition;
+  perSceneKey: string;
+  perJobKey: string;
+} {
+  const def: CharacterDefinition = {
+    ...emptyDefinition(),
+    mainTrainingId: 'field-tinkerer',
+    takenNodes: [{ trainingId: 'field-tinkerer', path: 'mundane', index: 1 }],
+  };
+  const abilities = usableAbilities(def);
+  const perSceneKey = abilities.find((a) => a.frequency === 'perScene')!.key;
+  const perJobKey = abilities.find((a) => a.frequency === 'perJob')!.key;
+  return { def, perSceneKey, perJobKey };
+}
+
+function seededSession(
+  characterId: string,
+  perSceneKey: string,
+  perJobKey: string,
+): SessionState {
+  return {
+    characterId,
+    momentum: 3,
+    wyrd: 5,
+    exposure: 2,
+    conditions: [{ id: 'shaken' }],
+    spentUses: [perSceneKey, perJobKey],
+  };
+}
+
+describe('newScene', () => {
+  it('zeroes Wyrd and clears only per-scene uses; keeps everything else', () => {
+    const { def, perSceneKey, perJobKey } = fixture();
+    const state = seededSession(def.id, perSceneKey, perJobKey);
+
+    const next = newScene(def, state);
+
+    expect(next.wyrd).toBe(0);
+    expect(next.spentUses).not.toContain(perSceneKey);
+    expect(next.spentUses).toContain(perJobKey);
+    // Momentum, Exposure and conditions persist across a scene.
+    expect(next.momentum).toBe(state.momentum);
+    expect(next.exposure).toBe(state.exposure);
+    expect(next.conditions).toEqual(state.conditions);
+  });
+
+  it('does not mutate the definition or the input state', () => {
+    const { def, perSceneKey, perJobKey } = fixture();
+    const state = seededSession(def.id, perSceneKey, perJobKey);
+    const defBefore = structuredClone(def);
+    const stateBefore = structuredClone(state);
+
+    const next = newScene(def, state);
+
+    expect(def).toEqual(defBefore);
+    expect(state).toEqual(stateBefore);
+    expect(next).not.toBe(state);
+  });
+});
+
+describe('newJob', () => {
+  it('clears everything including Exposure, preserving the character id', () => {
+    const { def, perSceneKey, perJobKey } = fixture();
+    const state = seededSession(def.id, perSceneKey, perJobKey);
+
+    const next = newJob(state);
+
+    expect(next).toEqual(emptySession(state.characterId));
+    expect(next.characterId).toBe(state.characterId);
+    expect(next.exposure).toBe(0);
+    expect(next).not.toBe(state);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 // Project page at https://jonasbausch.github.io/side-quest-llc/ — the base path
@@ -6,4 +6,10 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   base: '/side-quest-llc/',
   plugins: [react()],
+  // Suite is pure logic (content validation, serialize, session resets), so the
+  // default node environment is enough — no jsdom/happy-dom needed.
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
 });


### PR DESCRIPTION
Closes #22.

## Why
`CLAUDE.md` repeatedly leans on "structural tests" (every training has a specialty, five gear nodes, five wyrd nodes, a non-empty tag list, and tag ids that resolve) as the discipline that catches silent transcription failures — but none existed. Training files only `satisfies Training`, a compile-time type check, so the Zod `trainingSchema` never actually ran against authored content. The only automated gate was `tsc -b` + lint.

## What
Adds Vitest with a focused suite. All tested logic is pure, so it runs in the default `node` environment — no jsdom/happy-dom dependency.

**Tooling**
- `vitest` dev dependency; `test` (`vitest run`) and `test:watch` scripts
- `vite.config.ts`: `node`-environment `test` block, `include: ['src/**/*.test.ts']`
- `.github/workflows/ci.yml`: `npm test` added to the merge gate (lint → test → build)

**Tests (3 files, 26 cases)**
- `src/content/content.test.ts` — runs `trainingSchema` against all 10 trainings (specialty + exactly 5 wyrd + 5 mundane + non-empty tags) and checks every `availableTagId` resolves in `spellTagsById`
- `src/lib/serialize.test.ts` — `encode → decode` round-trip on a fully-populated definition + null-return guards
- `src/lib/storage.test.ts` — `newScene` zeroes Wyrd and clears only per-scene uses (keeps per-job/momentum/exposure/conditions); `newJob` clears everything incl. exposure; both leave definition + input state untouched. Spent-use keys derived via `usableAbilities()` to stay generic over content.

## Acceptance criteria
- [x] Content structural tests over every training
- [x] Tag-id resolution test against `spellTags`
- [x] `serialize` round-trip test
- [x] Storage tests for scene/job reset scope + definition isolation
- [x] `test` script wired in and added to the CI quality gate

## Verification
- `npm test` → 3 files, 26 passed
- `npm run lint` and `npm run build` → clean
- Negative check: breaking a tag id fails the resolution test; reverting restores green (suite isn't vacuously passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xd9x9jxXhMt3KUm41tJSTL