### PR TITLE
Tag Occult Freelancer trope as perJob (#23)

### DIFF
--- a/src/content/tropes.ts
+++ b/src/content/tropes.ts
@@ -64,6 +64,7 @@ export const tropes = [
     id: 'occult-freelancer',
     name: 'Occult Freelancer',
     text: `You start each job with one extra contact "on retainer" (one call/text for a useful fact, tool, or introduction).`,
+    frequency: 'perJob',
   },
   {
     id: 'reluctant-hero',


### PR DESCRIPTION
Part of #23 — the unambiguous slice.

**Occult Freelancer**'s "one call/text on retainer" is a per-job consumable. It was untagged, so it never surfaced as a spendable use in the tracker — it sat in the read-only Kit. Tagging it `perJob` makes it a checkbox that resets on New Job, matching how the resource actually works at the table.

Reconciled the full trope/strength/flaw set against `docs/rules-v5.0.md` (lines 1200–1258). Every explicitly-worded "once per scene/job" entry was already correct; the situational `-1`/bonus passives were correctly untagged. Three genuine judgment calls where the PDF cadence doesn't map cleanly onto the enum are split out into their own issues for a GM ruling rather than guessed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)