### PR TITLE
Fix Crowd Liaison display name, keep the id

### DIFF
--- a/src/content/trainings/crowd-liason.ts
+++ b/src/content/trainings/crowd-liason.ts
@@ -1,17 +1,23 @@
 import type { Training } from '../schema';
 
 /**
- * Crowd Liason — "Please stop filming."
+ * Crowd Liaison — "Please stop filming."
  * Transcribed verbatim from docs/rules-v5.0.md ("Crowd Liason").
  *
- * Spelling conflict, flagged: the Training Options list and this section header
- * both spell it "Crowd Liason"; the glossary spells it "Crowd Liaison". The
- * training text wins over the glossary, so the name/id follow "Liason".
+ * Spelling: the Training Options list and this section header spell it "Crowd
+ * Liason", the glossary spells it "Crowd Liaison". GM confirmed the tables are
+ * a typo, so the display name is "Liaison".
+ *
+ * The id stays `crowd-liason`. It is a storage key, not a spelling: it is
+ * serialized into share links and stored characters, and nothing resolves an
+ * id that no longer exists — a renamed id silently drops the main training and
+ * every node taken in it. Do not "fix" it without an alias.
+ *
  * Wyrd-4 is Thin-Place Etiquette, inline (states its own once-per-scene).
  */
 export const crowdLiason = {
   id: 'crowd-liason',
-  name: 'Crowd Liason',
+  name: 'Crowd Liaison',
   tagline: `Please stop filming.`,
   specialty: {
     name: `Men in Beige`,


### PR DESCRIPTION
Closes #19.

GM confirmed "Liason" in the training tables is a typo — the glossary's "Crowd Liaison" is canonical. So this changes the **display name** only.

## The id stays `crowd-liason`

The id and name are independent literals; nothing derives one from the other, and the id is never shown to users. It appears outside the training file only as the import path in `src/content/index.ts`.

Renaming it would be a breaking change for existing sheets, and a quiet one. `mainTrainingId` is `z.string().min(1)`, not an enum against the registry, so a stale id decodes fine and then fails to resolve:

- `trainingsById.get()` misses — specialty gone, node columns empty, and the `<select>` matches no `<option>` and renders blank
- `resolveNode` returns undefined and `characterAbilities` skips it, so taken nodes vanish from the tracker's Uses and loadout with no warning
- the only signal is `validateDefinition` saying "No main training selected", which reads as user error rather than a dead id
- the rules-version banner does not catch it — a spelling fix does not bump `rulesVersion`

Session state is keyed by `def.id`, so it is unaffected; some `spentUses` keys embed the old training id and go orphaned, but they are inert and `newJob` clears them.

At least one existing character has a Crowd Liaison sheet, so this stays as-is. The header comment now records the reasoning so the id does not get "fixed" later. If it is ever renamed for tidiness it needs an alias, and that belongs in `src/content/` (e.g. a `formerIds` field folded into `trainingsById`) rather than `src/lib/`, so no component or lib function names a specific training.

## Verification

- `npm run build` (`tsc -b` + vite) passes
- 26 tests pass
- Behaviour confirmed with a throwaway test that round-tripped a definition carrying a stale training id through `encodeDefinition`/`decodeDefinition` — link still loads, old ids survive intact, content silently drops. Not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174DcTUKbBSUgymcvaTQqMT