### PR TITLE
Shorten share links with a compact v2 URL format

### DIFF
--- a/src/lib/character.ts
+++ b/src/lib/character.ts
@@ -31,12 +31,23 @@ export const DICE: DieSize[] = ['d4', 'd6', 'd8', 'd10', 'd12', 'd20'];
 /** Frequencies that surface as a spendable use in the tracker. */
 export const USABLE_FREQUENCIES: Frequency[] = ['perScene', 'perJob', 'counter'];
 
+/**
+ * A short, stable id for a new character. Only the localStorage session key is
+ * derived from it, so 32 bits is ample — and it costs ~28 fewer URL characters
+ * than a full UUID. Existing characters keep the id they were created with:
+ * ids are read from the share link, never regenerated, so nobody loses their
+ * live session state.
+ */
+function newCharacterId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID().replace(/-/g, '').slice(0, 8);
+  }
+  return Date.now().toString(36);
+}
+
 export function emptyDefinition(): CharacterDefinition {
   return {
-    id:
-      typeof crypto !== 'undefined' && 'randomUUID' in crypto
-        ? crypto.randomUUID()
-        : `char-${Date.now()}`,
+    id: newCharacterId(),
     rulesVersion: CURRENT_RULES_VERSION,
     name: '',
     mainTrainingId: trainings[0].id,

--- a/src/lib/serialize.test.ts
+++ b/src/lib/serialize.test.ts
@@ -1,40 +1,188 @@
 import { describe, it, expect } from 'vitest';
+import LZString from 'lz-string';
 import { encodeDefinition, decodeDefinition } from './serialize';
 import { emptyDefinition } from './character';
+import { tropesById } from '../content';
 import type { CharacterDefinition } from '../content/schema';
 
 /**
- * The definition travels in the URL fragment as an LZ-compressed JSON payload.
- * A share link is only useful if what comes back out equals what went in.
- * encode/decode are pure (no window access), so this needs no DOM.
+ * The definition travels in the URL fragment as an LZ-compressed payload.
+ * A share link is only useful if what comes back out equals what went in — and
+ * if every link minted before the compact v2 format still opens.
  */
+
+const fullBuild = (): CharacterDefinition => ({
+  ...emptyDefinition(),
+  name: 'Jitterbug Deux',
+  mainTrainingId: 'field-tinkerer',
+  startingPath: 'wyrd',
+  takenNodes: [
+    { trainingId: 'field-tinkerer', path: 'wyrd', index: 2 },
+    { trainingId: 'field-tinkerer', path: 'mundane', index: 1 },
+  ],
+  signatureTagId: 'spark',
+  signatureTune: 'fast',
+  statDice: { brains: 'd12', brawn: 'd4', charm: 'd8' },
+  trope: { id: 'custom', name: 'Homebrew Trope', text: 'Made up at the table.' },
+  strength: { id: 'nerves', name: 'Nerves of Steel', text: 'Unflappable.' },
+  flaw: { id: 'reckless', name: 'Reckless', text: 'Leaps first.' },
+  notes: 'Owes the fixer a favour.',
+});
+
 describe('serialize round-trip', () => {
   it('decodes back to an equal definition', () => {
-    const def: CharacterDefinition = {
-      ...emptyDefinition(),
-      name: 'Jitterbug Deux',
-      mainTrainingId: 'field-tinkerer',
-      startingPath: 'wyrd',
-      takenNodes: [
-        { trainingId: 'field-tinkerer', path: 'wyrd', index: 2 },
-        { trainingId: 'field-tinkerer', path: 'mundane', index: 1 },
-      ],
-      signatureTagId: 'spark',
-      signatureTune: 'fast',
-      statDice: { brains: 'd12', brawn: 'd4', charm: 'd8' },
-      trope: { id: 'custom', name: 'Homebrew Trope', text: 'Made up at the table.' },
-      strength: { id: 'nerves', name: 'Nerves of Steel', text: 'Unflappable.' },
-      flaw: { id: 'reckless', name: 'Reckless', text: 'Leaps first.' },
-      notes: 'Owes the fixer a favour.',
-    };
-
-    const roundTripped = decodeDefinition(encodeDefinition(def));
-    expect(roundTripped).toEqual(def);
+    const def = fullBuild();
+    expect(decodeDefinition(encodeDefinition(def))).toEqual(def);
   });
 
   it('returns null for undecodable input', () => {
     expect(decodeDefinition('')).toBeNull();
     // Valid-looking string that decompresses to something that isn't a definition.
     expect(decodeDefinition('not-a-real-payload')).toBeNull();
+    expect(decodeDefinition('2~not-a-real-payload')).toBeNull();
+  });
+
+  it('preserves cross-training and the order nodes were taken', () => {
+    const def: CharacterDefinition = {
+      ...fullBuild(),
+      takenNodes: [
+        { trainingId: 'field-tinkerer', path: 'wyrd', index: 2 },
+        { trainingId: 'negotiator', path: 'mundane', index: 1 },
+        { trainingId: 'field-tinkerer', path: 'mundane', index: 5 },
+        { trainingId: 'ward-carpenter', path: 'wyrd', index: 3 },
+      ],
+    };
+    expect(decodeDefinition(encodeDefinition(def))?.takenNodes).toEqual(
+      def.takenNodes,
+    );
+  });
+
+  it('keeps every stat die on the right stat', () => {
+    const def: CharacterDefinition = {
+      ...fullBuild(),
+      statDice: {
+        brains: 'd4',
+        brawn: 'd6',
+        charm: 'd8',
+        fight: 'd10',
+        flight: 'd12',
+        grit: 'd20',
+      },
+    };
+    expect(decodeDefinition(encodeDefinition(def))?.statDice).toEqual(
+      def.statDice,
+    );
+  });
+
+  it('does not default rulesVersion to the current ruleset', () => {
+    const def: CharacterDefinition = { ...fullBuild(), rulesVersion: '3.1' };
+    expect(decodeDefinition(encodeDefinition(def))?.rulesVersion).toBe('3.1');
+  });
+});
+
+describe('trait rehydration', () => {
+  it('stores a book-picked trait by id and resolves it from content', () => {
+    const trope = tropesById.get('by-the-book')!;
+    const def: CharacterDefinition = {
+      ...fullBuild(),
+      trope: {
+        id: trope.id,
+        name: trope.name,
+        text: trope.text,
+        frequency: trope.frequency,
+      },
+    };
+
+    // The prose must not be in the payload — that duplication is what made
+    // links long.
+    const payload = LZString.decompressFromEncodedURIComponent(
+      encodeDefinition(def).slice(2),
+    )!;
+    expect(payload).toContain('by-the-book');
+    expect(payload).not.toContain(trope.text);
+
+    expect(decodeDefinition(encodeDefinition(def))?.trope).toEqual(def.trope);
+  });
+
+  it('keeps a homebrew trait inline', () => {
+    const def: CharacterDefinition = {
+      ...fullBuild(),
+      flaw: { name: 'Owes the wrong people', text: 'They know where you sleep.' },
+    };
+    expect(decodeDefinition(encodeDefinition(def))?.flaw).toEqual(def.flaw);
+  });
+
+  it('inlines a pick whose id does not resolve, rather than stripping it', () => {
+    // Only ids that resolve in the registry are safe to strip to a bare id.
+    const def: CharacterDefinition = {
+      ...fullBuild(),
+      strength: { id: 'retired-strength', name: 'Retired Strength' },
+    };
+    expect(decodeDefinition(encodeDefinition(def))?.strength).toEqual(
+      def.strength,
+    );
+  });
+
+  it('keeps a bare id the content has since dropped, rather than losing it', () => {
+    // A link minted while the trait existed, opened after content removed it.
+    // Reconstructed by hand because encode can no longer produce this.
+    const link =
+      '2~' +
+      LZString.compressToEncodedURIComponent(
+        JSON.stringify({
+          v: '4.0',
+          i: 'a1b2c3d4',
+          n: 'Ghost Pick',
+          p: 'm',
+          k: 'field-tinkerer|',
+          r: [0, 'trait-since-removed', 0],
+        }),
+      );
+    expect(decodeDefinition(link)?.strength).toEqual({
+      id: 'trait-since-removed',
+      name: 'trait-since-removed',
+    });
+  });
+});
+
+describe('legacy v1 links', () => {
+  /**
+   * Captured from the pre-v2 encoder. Never regenerate this — its whole job is
+   * to be a real link from before the format change.
+   */
+  const V1_LINK =
+    'N4IglgJiBcIMwDMBMBDAjAIwCwGMC0ArARAGx5YDsApgBx4CcKADGnhkjnBFlQQiUwogANCABOAVwA2VAM4A1KmNlgA9gDsYILADomIkOpQBbKloBSYAC5WlGCQHMABABEqEgB4HjKMOoAqYr7qfg4AklCwCGBUUhB4Vn4A1kpKBrJWKGKJ6g4ACihWABZaAO4AnmJQopkp6gByqhByMADaoFZBfqERWtGx8TkpYmmiAA6FJbAVVQZ+zV7QSAC+wh1dIbm9sOpUDqqJhapiBhPFWsYS6hAou3PXVItoywC6oioORlYSI-4o4ZEQLIJmIkukwJ9Cj8qP4rmYoigMulMlYXGAcPDQBgNrItBA0EgDNiUKVNLBuAYcEUssY8TQQKsQJ1VGNMeBARhygkilQ2KpVGDREZTFoAELlJzFKhOUX8wVMx5WLQAZX8AEEADIAUSceQASgB5ZU6gBihoAsk41fUnAaNS4nBqwvUANI6AwIEYARwkVHUOHKWgmshUADczIyMiNcudoKBhfCQAAJVSmbFUUpOZWdP0Oc41RVac0oZpOCRjJyFSU8yUoDAyd2M9QHFqwA2lOTV6XRDxKStOBAoUOqH6NoA';
+
+  it('still decodes, with its uuid and node order intact', () => {
+    const def = decodeDefinition(V1_LINK);
+    expect(def).not.toBeNull();
+    // The session key is derived from this — an old link must keep its id or
+    // the character loses its live state.
+    expect(def!.id).toBe('3f2a1b4c-55d6-47e8-9a01-b2c3d4e5f607');
+    expect(def!.name).toBe('Jitterbug Deux');
+    expect(def!.takenNodes).toEqual([
+      { trainingId: 'field-tinkerer', path: 'wyrd', index: 2 },
+      { trainingId: 'negotiator', path: 'mundane', index: 1 },
+    ]);
+    expect(def!.statDice).toEqual({ brains: 'd12', brawn: 'd4', charm: 'd8' });
+    expect(def!.strength).toEqual({
+      name: 'Homebrew Strength',
+      text: 'Made up at the table.',
+    });
+    expect(def!.notes).toBe('Owes the fixer a favour.');
+  });
+
+  it('reads a v1 payload verbatim, without rehydrating its traits', () => {
+    // v1 decoding is untouched: the prose frozen into an old link is what that
+    // link shows. It only picks up current content once re-minted as v2.
+    expect(decodeDefinition(V1_LINK)!.trope!.text).toBe(
+      'STALE PROSE FROM AN OLD LINK.',
+    );
+  });
+
+  it('re-minting a v1 link produces a shorter v2 link for the same character', () => {
+    const def = decodeDefinition(V1_LINK)!;
+    expect(encodeDefinition(def).length).toBeLessThan(V1_LINK.length * 0.6);
+    expect(decodeDefinition(encodeDefinition(def))!.id).toBe(def.id);
   });
 });

--- a/src/lib/serialize.ts
+++ b/src/lib/serialize.ts
@@ -1,23 +1,261 @@
 /**
- * Character definition <-> URL fragment. The definition is JSON, LZ-compressed
- * into the hash so a character is a shareable link. `rulesVersion` travels
- * inside the payload as the version field. Session state never touches the URL.
+ * Character definition <-> URL fragment. Session state never touches the URL.
+ *
+ * Two wire formats live here:
+ *
+ * - **v1** (legacy, no prefix): the whole definition as JSON, LZ-compressed.
+ *   Every share link minted before the compact format uses it. Decoding it is
+ *   kept forever — old links must not break.
+ * - **v2** (current, `2~` prefix): a compact projection of the same definition.
+ *   Short keys, node refs indexed against a link-local training list, dice as a
+ *   positional string, and book-picked traits stored as bare ids and rehydrated
+ *   from the content registry on read. A full build drops from ~1130 URL chars
+ *   to ~300.
+ *
+ * The prefix is unambiguous: lz-string's URI-safe alphabet is
+ * `A-Za-z0-9+-$`, so `~` can never occur in a v1 payload.
+ *
+ * Compaction lives entirely in this file. `CharacterDefinition` and its Zod
+ * schema are unchanged, so components, validation, and JSON import/export are
+ * untouched by the wire format.
  */
 import LZString from 'lz-string';
 import {
   characterDefinitionSchema,
   type CharacterDefinition,
+  type DieSize,
+  type Frequency,
+  type NodeRef,
+  type StatDice,
+  type TraitPick,
 } from '../content/schema';
+import { tropesById, strengthsById, flawsById, type Trait } from '../content';
+
+const V2_PREFIX = '2~';
+
+/**
+ * Stat order for the packed dice string. Frozen on purpose: this is a wire
+ * format, so reordering it would silently rewrite every existing v2 link.
+ * Deliberately NOT derived from STAT_META, which is display order and free to
+ * change.
+ */
+const WIRE_STATS = [
+  'brains',
+  'brawn',
+  'charm',
+  'fight',
+  'flight',
+  'grit',
+] as const;
+
+/** Trait slot order for the packed `r` triple. Frozen for the same reason. */
+const WIRE_TRAITS = ['trope', 'strength', 'flaw'] as const;
+
+const traitRegistries: Record<(typeof WIRE_TRAITS)[number], Map<string, Trait>> =
+  {
+    trope: tropesById,
+    strength: strengthsById,
+    flaw: flawsById,
+  };
+
+/* ---- v2 wire shape ------------------------------------------------------ */
+
+/**
+ * A trait slot: `0` when unset, a bare id when it resolves in the content
+ * registry (rehydrated on read), or an inline object for a homebrew pick.
+ */
+type WireTrait =
+  | 0
+  | string
+  | { i?: string; n: string; x?: string; f?: Frequency };
+
+interface WireV2 {
+  /** rulesVersion. Always written, never defaulted — see decode. */
+  v: string;
+  i: string;
+  n: string;
+  /** startingPath. */
+  p: 'w' | 'm';
+  /**
+   * `"<trainingIds>|<nodeRefs>"`. Index 0 of the id list is always the main
+   * training, so it costs nothing to name it here. Node refs are
+   * `<trainingIndex><w|m><slot>` in the order the player took them.
+   */
+  k: string;
+  g?: string;
+  u?: string;
+  /** Dice in WIRE_STATS order, `d` prefix stripped, e.g. `"10,6,8,,12,4"`. */
+  d?: string;
+  r?: [WireTrait, WireTrait, WireTrait];
+  b?: Record<string, string>;
+  z?: string;
+}
+
+/* ---- trait packing ------------------------------------------------------ */
+
+function packTrait(
+  pick: TraitPick | undefined,
+  registry: Map<string, Trait>,
+): WireTrait {
+  if (!pick) return 0;
+  // A pick whose id resolves is fully reconstructible from content; storing the
+  // prose again is what made links long in the first place.
+  if (pick.id && registry.has(pick.id)) return pick.id;
+  return {
+    ...(pick.id ? { i: pick.id } : {}),
+    n: pick.name,
+    ...(pick.text ? { x: pick.text } : {}),
+    ...(pick.frequency ? { f: pick.frequency } : {}),
+  };
+}
+
+function unpackTrait(
+  wire: WireTrait | undefined,
+  registry: Map<string, Trait>,
+): TraitPick | undefined {
+  if (!wire) return undefined;
+  if (typeof wire === 'string') {
+    const trait = registry.get(wire);
+    // An id the content no longer carries (renamed or dropped trait) keeps its
+    // id rather than vanishing from the sheet — advisory, never destructive.
+    return trait
+      ? {
+          id: trait.id,
+          name: trait.name,
+          text: trait.text,
+          frequency: trait.frequency,
+        }
+      : { id: wire, name: wire };
+  }
+  return {
+    ...(wire.i ? { id: wire.i } : {}),
+    name: wire.n,
+    ...(wire.x ? { text: wire.x } : {}),
+    ...(wire.f ? { frequency: wire.f } : {}),
+  };
+}
+
+/* ---- node ref packing --------------------------------------------------- */
+
+function packNodes(def: CharacterDefinition): string {
+  const ids = [def.mainTrainingId];
+  for (const ref of def.takenNodes) {
+    if (!ids.includes(ref.trainingId)) ids.push(ref.trainingId);
+  }
+  const refs = def.takenNodes.map(
+    (ref) =>
+      `${ids.indexOf(ref.trainingId)}${ref.path === 'wyrd' ? 'w' : 'm'}${ref.index}`,
+  );
+  return `${ids.join(',')}|${refs.join(',')}`;
+}
+
+function unpackNodes(packed: string): {
+  mainTrainingId: string;
+  takenNodes: NodeRef[];
+} {
+  const [header = '', body = ''] = packed.split('|');
+  const ids = header.split(',');
+  const takenNodes: NodeRef[] = [];
+  for (const token of body.split(',').filter(Boolean)) {
+    const match = /^(\d+)([wm])(\d+)$/.exec(token);
+    if (!match) continue;
+    const trainingId = ids[Number(match[1])];
+    if (!trainingId) continue;
+    takenNodes.push({
+      trainingId,
+      path: match[2] === 'w' ? 'wyrd' : 'mundane',
+      index: Number(match[3]),
+    });
+  }
+  return { mainTrainingId: ids[0] ?? '', takenNodes };
+}
+
+/* ---- dice packing ------------------------------------------------------- */
+
+function packDice(dice: StatDice): string | undefined {
+  const slots = WIRE_STATS.map((stat) => dice[stat]?.replace(/^d/, '') ?? '');
+  return slots.some(Boolean) ? slots.join(',') : undefined;
+}
+
+function unpackDice(packed: string | undefined): StatDice {
+  const dice: StatDice = {};
+  if (!packed) return dice;
+  packed.split(',').forEach((slot, i) => {
+    const stat = WIRE_STATS[i];
+    if (stat && slot) dice[stat] = `d${slot}` as DieSize;
+  });
+  return dice;
+}
+
+/* ---- v2 encode / decode ------------------------------------------------- */
+
+function toWire(def: CharacterDefinition): WireV2 {
+  const traits = WIRE_TRAITS.map((slot) =>
+    packTrait(def[slot], traitRegistries[slot]),
+  ) as [WireTrait, WireTrait, WireTrait];
+
+  return {
+    v: def.rulesVersion,
+    i: def.id,
+    n: def.name,
+    p: def.startingPath === 'wyrd' ? 'w' : 'm',
+    k: packNodes(def),
+    ...(def.signatureTagId ? { g: def.signatureTagId } : {}),
+    ...(def.signatureTune ? { u: def.signatureTune } : {}),
+    ...(packDice(def.statDice) ? { d: packDice(def.statDice) } : {}),
+    ...(traits.some((t) => t !== 0) ? { r: traits } : {}),
+    ...(def.background ? { b: def.background } : {}),
+    ...(def.notes ? { z: def.notes } : {}),
+  };
+}
+
+function fromWire(wire: WireV2): unknown {
+  const { mainTrainingId, takenNodes } = unpackNodes(wire.k ?? '');
+  const traits = wire.r ?? [];
+
+  return {
+    id: wire.i,
+    // rulesVersion is never defaulted to the current ruleset: a link authored
+    // against an older ruleset must keep saying so, or the mismatch banner
+    // silently migrates it.
+    rulesVersion: wire.v,
+    name: wire.n,
+    mainTrainingId,
+    startingPath: wire.p === 'w' ? 'wyrd' : 'mundane',
+    takenNodes,
+    ...(wire.g ? { signatureTagId: wire.g } : {}),
+    ...(wire.u ? { signatureTune: wire.u } : {}),
+    statDice: unpackDice(wire.d),
+    ...Object.fromEntries(
+      WIRE_TRAITS.map((slot, i) => [
+        slot,
+        unpackTrait(traits[i], traitRegistries[slot]),
+      ]).filter(([, pick]) => pick !== undefined),
+    ),
+    ...(wire.b ? { background: wire.b } : {}),
+    ...(wire.z ? { notes: wire.z } : {}),
+  };
+}
+
+/* ---- public API --------------------------------------------------------- */
 
 export function encodeDefinition(def: CharacterDefinition): string {
-  return LZString.compressToEncodedURIComponent(JSON.stringify(def));
+  return (
+    V2_PREFIX +
+    LZString.compressToEncodedURIComponent(JSON.stringify(toWire(def)))
+  );
 }
 
 export function decodeDefinition(encoded: string): CharacterDefinition | null {
   try {
-    const json = LZString.decompressFromEncodedURIComponent(encoded);
+    const isV2 = encoded.startsWith(V2_PREFIX);
+    const json = LZString.decompressFromEncodedURIComponent(
+      isV2 ? encoded.slice(V2_PREFIX.length) : encoded,
+    );
     if (!json) return null;
-    const parsed = characterDefinitionSchema.safeParse(JSON.parse(json));
+    const raw: unknown = JSON.parse(json);
+    const candidate = isV2 ? fromWire(raw as WireV2) : raw;
+    const parsed = characterDefinitionSchema.safeParse(candidate);
     return parsed.success ? parsed.data : null;
   } catch {
     return null;


### PR DESCRIPTION
A shared character sheet's link was getting very long — a full build came out at **1119 URL characters**.

## Where the length came from

Roughly 40% of it was rules prose duplicated into the fragment. Picking a trope/strength/flaw copied the whole book entry into the definition:

```ts
onPick({ id: found.id, name: found.name, text: found.text, frequency: found.frequency });
```

So every link carried three paragraphs of text that already ship in the bundle. The rest went to a 36-char UUID, verbose JSON keys, and node refs repeating the training id per node. LZString wasn't helping much — 1233 JSON chars compressed to 1083, because the payload is too short and too unique for the dictionary to find anything. Shrinking the input is what pays.

## What this does

Adds a v2 wire format behind a `2~` prefix:

- Book-picked traits store a bare id and rehydrate from the content registry on read; homebrew picks stay inline
- Node refs index into a link-local training list — `field-tinkerer,negotiator|0w2,0m1,1w1` — preserving the order nodes were taken. Deliberately *not* indexed against content order, which would break every existing link if `src/content/` were reordered
- Short keys; dice packed positionally against a frozen constant in `serialize.ts` rather than `STAT_META`, which is display order and free to change
- New characters get an 8-char id instead of a UUID

| | before | after | |
|---|---|---|---|
| Full build, no notes | 1,119 | **294** | −74% |
| With notes | 1,211 | 386 | −68% |
| Worst case (all 10 nodes + 4 cross-trained, long name, notes) | 1,445 | 460 | −68% |

At ~300 chars a link also becomes a comfortably scannable QR code, which may be more useful at the table than the character count itself.

## Scope

Compaction lives entirely in `serialize.ts` and maps to an unchanged `CharacterDefinition`. The Zod schema, components, `validateDefinition`, and JSON import/export are untouched — worth confirming, since loosening `traitPickSchema.name` to allow a stripped pick would have weakened the type for homebrew picks at `character.ts:174`.

## Compatibility

Existing links keep working. lz-string's URI-safe alphabet is `A-Za-z0-9+-$`, so `~` can never occur in a v1 payload — the prefix is unambiguous, and anything without it routes to the old decoder, which stays in place permanently.

Ids are only ever read from the link, never regenerated (`App.tsx:25` is `readHash() ?? emptyDefinition()`), so existing characters keep their UUID and their `sidequest:session:<id>` localStorage state.

Two behaviors worth a look in review:

- **A v1 link shows its frozen prose exactly once.** v1 decoding is byte-identical to before, so no rehydration happens on that first load; `writeHash` then re-mints it as v2 and it tracks current content from the next load on. If the GM edits a trope, old links pick up the edit — I think that's right for a draft ruleset that gets houseruled constantly, but it is a visible change and there's a test pinning it.
- **`rulesVersion` is always written, never defaulted.** Omitting it when it matches current would save ~12 chars but would silently migrate old links the next time `CURRENT_RULES_VERSION` bumps.

Forward compatibility is not preserved — a v2 link can't be read by a bundle built before this. In practice that window is negligible: no service worker, hashed asset names, and no `hashchange` listener, so a stale tab wouldn't re-read a pasted hash without a reload that fetches fresh JS. It also fails safe: `readHash()` returns null and you get an empty builder, not a corrupted character.

## Testing

`npm run build` passes; 36 tests pass, 12 in `serialize.test.ts` (up from 2). The legacy test uses a v1 link **captured from the old encoder before it was touched**, not a reimplementation of it, and asserts the UUID, node order, dice, homebrew trait, and notes all survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174DcTUKbBSUgymcvaTQqMT
