### PR TITLE
Add Group Bonuses to the tracker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,8 @@ Take from it:
 - Scene-state feedback. The Wyrd track changes the page background at 4 and
   again at 6, readable in peripheral vision without focusing on it.
 - Reset semantics. "New scene" clears per-scene uses and zeroes Wyrd. "New job"
-  clears everything including Exposure. These map to real table moments.
+  clears everything including Exposure, except Momentum, which carries between
+  jobs. These map to real table moments.
 - Progression as unlock. Nodes not yet taken are visible but inert, so players
   can see what a promotion buys them.
 - The visual direction: work-order stock, condensed industrial display type,

--- a/docs/rules-v5.0.md
+++ b/docs/rules-v5.0.md
@@ -1419,6 +1419,8 @@ When you **fail a roll** by **5 or more** gain **+2 Momentum**.
 
 You may have a maximum of **10 Momentum** at one time. If you have **10 Momentum** you cannot earn more until you have spent some.
 
+Momentum **carries over between jobs**. It is not reset at the end of a job, which is what makes the more expensive Group Bonuses reachable.
+
 ---
 
 **Spend Momentum (choose one):**

--- a/src/components/Tracker.tsx
+++ b/src/components/Tracker.tsx
@@ -402,13 +402,17 @@ export function Tracker({ def, session, onChange, onDefChange }: TrackerProps) {
         <button
           className="reset danger"
           onClick={() => {
-            if (window.confirm('New job clears everything, including Exposure. Continue?')) {
+            if (
+              window.confirm(
+                'New job clears Exposure, Wyrd, conditions and all uses. Momentum carries. Continue?',
+              )
+            ) {
               onChange(newJob(session));
             }
           }}
         >
           New job
-          <small>clears everything</small>
+          <small>clears all but Momentum</small>
         </button>
       </section>
     </div>

--- a/src/components/Tracker.tsx
+++ b/src/components/Tracker.tsx
@@ -11,8 +11,17 @@ import {
   wyrdTrack,
   momentumGuide,
   exposureGuide,
+  groupBonusGuide,
+  groupBonuses,
 } from '../content';
-import { STAT_META, usableAbilities, passiveAbilities } from '../lib/character';
+import {
+  STAT_META,
+  usableAbilities,
+  passiveAbilities,
+  hasGroupBonus,
+  toggleGroupBonus,
+  unlockedGroupBonuses,
+} from '../lib/character';
 import { newJob, newScene } from '../lib/storage';
 
 const MAX_MOMENTUM = 10;
@@ -21,7 +30,10 @@ interface TrackerProps {
   def: CharacterDefinition;
   session: SessionState;
   onChange: (session: SessionState) => void;
-  /** Edits the character definition. Notes are definition data, not session. */
+  /**
+   * Edits the character definition. Notes and unlocked Group Bonuses are
+   * definition data, not session — they must survive "New job".
+   */
   onDefChange: (def: CharacterDefinition) => void;
 }
 
@@ -337,6 +349,13 @@ export function Tracker({ def, session, onChange, onDefChange }: TrackerProps) {
         )}
       </section>
 
+      {/* Crew --------------------------------------------------------- */}
+      <CrewSection
+        def={def}
+        momentum={session.momentum}
+        onDefChange={onDefChange}
+      />
+
       {/* Passives + traits ------------------------------------------- */}
       {passives.length > 0 && (
         <section className="card">
@@ -512,5 +531,115 @@ function UseGroup({
         );
       })}
     </div>
+  );
+}
+
+/**
+ * Group Bonuses. Crew-level in the fiction, recorded per player: the table
+ * agrees on a purchase out loud and everyone marks it here, the same way a
+ * promotion is recorded. Nothing is spent or enforced — locked levels stay
+ * visible but inert so players can see what the crew could save toward.
+ *
+ * Unlocking writes the *definition*, so a bonus survives "New job". The
+ * once-per-job levels then show up in Uses like any other ability, and it is
+ * the existing spentUses machinery that ticks and resets them.
+ */
+function CrewSection({
+  def,
+  momentum,
+  onDefChange,
+}: {
+  def: CharacterDefinition;
+  momentum: number;
+  onDefChange: (def: CharacterDefinition) => void;
+}) {
+  const unlocked = unlockedGroupBonuses(def);
+
+  const families = groupBonuses.reduce<
+    { group: string; levels: typeof groupBonuses }[]
+  >((acc, bonus) => {
+    const family = acc.find((f) => f.group === bonus.group);
+    if (family) family.levels.push(bonus);
+    else acc.push({ group: bonus.group, levels: [bonus] });
+    return acc;
+  }, []);
+
+  return (
+    <section className="card">
+      <h2>
+        Crew <span className="cap">group bonuses</span>
+      </h2>
+
+      {unlocked.length === 0 ? (
+        <p className="muted small">
+          Nothing unlocked yet. Agree a purchase at the table, then everyone
+          marks it below.
+        </p>
+      ) : (
+        <ul className="crew-owned">
+          {unlocked.map((b) => (
+            <li key={b.id}>
+              <span className="crew-owned-name">{b.name}</span>
+              <span className="crew-owned-source">{b.group}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <details className="cheat">
+        <summary>Unlock a group bonus</summary>
+        <p className="cheat-meta">{groupBonusGuide.purchase}</p>
+
+        {families.map((family) => (
+          <div key={family.group} className="crew-family">
+            <h3>
+              {family.group}
+              <span className="crew-price">
+                {family.levels[0].costPerPlayer}/player
+              </span>
+            </h3>
+            {family.levels.map((bonus) => {
+              const owned = hasGroupBonus(def, bonus.id);
+              const afford = momentum >= bonus.costPerPlayer;
+              return (
+                <label
+                  key={bonus.id}
+                  className={
+                    'crew-level' +
+                    (owned ? ' owned' : '') +
+                    (!owned && afford ? ' afford' : '')
+                  }
+                >
+                  <input
+                    type="checkbox"
+                    checked={owned}
+                    onChange={() => onDefChange(toggleGroupBonus(def, bonus.id))}
+                  />
+                  <span className="crew-body">
+                    <span className="crew-name">
+                      {family.levels.length > 1 && (
+                        <span className="crew-level-no">L{bonus.level}</span>
+                      )}
+                      {bonus.name}
+                      {bonus.frequency === 'perJob' && (
+                        <em className="crew-freq">1/job</em>
+                      )}
+                    </span>
+                    <span className="crew-text">{bonus.text}</span>
+                    {bonus.note && (
+                      <span className="crew-note">GM call: {bonus.note}</span>
+                    )}
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        ))}
+
+        {groupBonusGuide.note && (
+          <p className="cheat-meta">GM call: {groupBonusGuide.note}</p>
+        )}
+      </details>
+    </section>
   );
 }

--- a/src/content/content.test.ts
+++ b/src/content/content.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { trainings, spellTagsById } from './index';
-import { trainingSchema } from './schema';
+import { trainings, spellTagsById, groupBonuses } from './index';
+import { trainingSchema, groupBonusGuideSchema } from './schema';
+import { groupBonusGuide } from './group-bonuses';
 
 /**
  * The "structural tests" CLAUDE.md relies on to catch silent transcription
@@ -29,4 +30,37 @@ describe('trainings', () => {
       }
     },
   );
+});
+
+describe('group bonuses', () => {
+  it('is structurally valid', () => {
+    expect(() => groupBonusGuideSchema.parse(groupBonusGuide)).not.toThrow();
+  });
+
+  it('has unique ids', () => {
+    const ids = groupBonuses.map((b) => b.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('levels within a family are contiguous from 1', () => {
+    const families = new Map<string, number[]>();
+    for (const b of groupBonuses) {
+      families.set(b.group, [...(families.get(b.group) ?? []), b.level]);
+    }
+    for (const [group, levels] of families) {
+      expect(
+        [...levels].sort((a, b) => a - b),
+        `${group} levels`,
+      ).toEqual(levels.map((_, i) => i + 1));
+    }
+  });
+
+  it('prices every level of a family identically', () => {
+    const priced = new Map<string, number>();
+    for (const b of groupBonuses) {
+      const seen = priced.get(b.group);
+      if (seen === undefined) priced.set(b.group, b.costPerPlayer);
+      else expect(b.costPerPlayer, `${b.group} price`).toBe(seen);
+    }
+  });
 });

--- a/src/content/group-bonuses.ts
+++ b/src/content/group-bonuses.ts
@@ -112,7 +112,7 @@ export const groupBonusGuide = {
       costPerPlayer: 5,
       frequency: 'passive',
       text: `Gain a crew-wide contact, major favor, or legacy asset (NPC, informant, safehouse, "retired" ghost, etc.). A permanent resource or relationship in the setting, mechanically accessible via flashbacks or downtime.`,
-      note: `5 per player against a Momentum cap of 10; whether Momentum carries between jobs is unwritten.`,
+      note: `5 per player against a Momentum cap of 10 — the crew banks toward this across jobs.`,
     },
   ],
 } satisfies GroupBonusGuide;

--- a/src/content/group-bonuses.ts
+++ b/src/content/group-bonuses.ts
@@ -1,0 +1,118 @@
+import type { GroupBonusGuide } from './schema';
+
+/**
+ * Group Bonuses. Transcribed from docs/rules-v5.0.md ("SideQuest Group
+ * Bonuses"). Reference prose only — the crew agrees on a purchase at the table
+ * and each player records it; nothing here spends Momentum or checks that
+ * everyone paid.
+ *
+ * Two gaps run through the whole section and are surfaced as GM-call notes
+ * rather than resolved:
+ * - Families with levels print one price on the header. Whether each level
+ *   costs that price separately, and whether levels must be bought in order,
+ *   is unwritten.
+ * - "Gear slot" (Full Gear Expansion) appears exactly once in v5.0, here. The
+ *   rules never establish gear as slot-based, so there is no slot count to
+ *   render against.
+ */
+export const groupBonusGuide = {
+  purchase: `All require every player to spend the listed Momentum at the same end-of-episode scene. If even one person can't/won't pay, the upgrade is not unlocked.`,
+  note: `Levelled families print a single per-player price on the header. Whether each level costs that again, and whether they must be taken in order, is a GM call.`,
+  bonuses: [
+    {
+      id: 'team-protocol-1',
+      group: 'Team Protocol',
+      name: `"On My Mark!"`,
+      level: 1,
+      costPerPlayer: 1,
+      frequency: 'perJob',
+      text: `Once per job, all PCs can act in the same beat (synchronized move and a +1 to everyone's next roll).`,
+    },
+    {
+      id: 'team-protocol-2',
+      group: 'Team Protocol',
+      name: `"Mutual Cover"`,
+      level: 2,
+      costPerPlayer: 1,
+      frequency: 'perJob',
+      text: `Once per job, anyone can transfer a Condition or any Momentum to any other player.`,
+    },
+    {
+      id: 'team-protocol-3',
+      group: 'Team Protocol',
+      name: `"Redundant Prep"`,
+      level: 3,
+      costPerPlayer: 1,
+      frequency: 'passive',
+      text: `If a job goes off the rails, you know how to fix it. (Share Momentum at a one-to-one ratio, forever.)`,
+      note: `Standing effect, not a once-per-job maneuver — it replaces the 2:1 Handoff cost for the crew.`,
+    },
+    {
+      id: 'arcane-advancement',
+      group: 'Arcane Advancement',
+      name: 'Arcane Advancement',
+      level: 1,
+      costPerPlayer: 2,
+      frequency: 'passive',
+      text: `One player of the group's choice (or by vote/roll) upgrades their Wyrd Die to the next available tier (d4→d8, d8→d12).`,
+      note: `The printed tiers skip d6 and d10; whether those are valid Wyrd Die sizes is a GM call. Apply the upgrade to your die assignment by hand.`,
+    },
+    {
+      id: 'group-asset-1',
+      group: 'Group Asset',
+      name: 'Specter Van',
+      level: 1,
+      costPerPlayer: 2,
+      frequency: 'passive',
+      text: `A vehicle kitted for Wyrd containment, stealth, and security.`,
+    },
+    {
+      id: 'group-asset-2',
+      group: 'Group Asset',
+      name: 'Null Field Emitter',
+      level: 2,
+      costPerPlayer: 2,
+      frequency: 'perJob',
+      text: `Once per job, the party can drop a Wyrd-dampening field (reduce Wyrd by 2 scene-wide, or block one Reality Surge).`,
+      note: `One use for the whole crew, not one each.`,
+    },
+    {
+      id: 'group-asset-3',
+      group: 'Group Asset',
+      name: 'Mobile Workshop',
+      level: 3,
+      costPerPlayer: 2,
+      frequency: 'passive',
+      text: `Repair, mod, or prep gear mid-mission.`,
+    },
+    {
+      id: 'group-asset-4',
+      group: 'Group Asset',
+      name: 'Field Archive',
+      level: 4,
+      costPerPlayer: 2,
+      frequency: 'passive',
+      text: `Secure digital (or arcane) storage; unlock "prep" flashbacks and clues more flexibly.`,
+    },
+    {
+      id: 'full-gear-expansion',
+      group: 'Full Gear Expansion',
+      name: 'Full Gear Expansion',
+      level: 1,
+      costPerPlayer: 3,
+      frequency: 'passive',
+      text: `Every PC gains an additional gear slot and immediately selects a new piece of gear or upgrade.`,
+      note: `v5.0 never defines gear slots anywhere else, so there is no slot count to raise — treat the extra pick as a GM call.`,
+    },
+    {
+      id: 'legacy-or-contact',
+      group: 'Legacy or Contact',
+      name: 'Legacy or Contact',
+      level: 1,
+      costPerPlayer: 5,
+      frequency: 'passive',
+      text: `Gain a crew-wide contact, major favor, or legacy asset (NPC, informant, safehouse, "retired" ghost, etc.). A permanent resource or relationship in the setting, mechanically accessible via flashbacks or downtime.`,
+      note: `5 per player against a Momentum cap of 10; whether Momentum carries between jobs is unwritten.`,
+    },
+  ],
+} satisfies GroupBonusGuide;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -9,6 +9,7 @@ import type {
   Tune,
   Trait,
   Condition,
+  GroupBonus,
 } from './schema';
 
 import { artifactHandler } from './trainings/artifact-handler';
@@ -31,6 +32,7 @@ import { conditions } from './conditions';
 import { wyrdTrack } from './wyrd';
 import { momentumGuide } from './momentum';
 import { exposureGuide } from './exposure';
+import { groupBonusGuide } from './group-bonuses';
 
 /** All trainings, alphabetical by display name. */
 export const trainings: Training[] = [
@@ -56,6 +58,7 @@ export {
   wyrdTrack,
   momentumGuide,
   exposureGuide,
+  groupBonusGuide,
 };
 
 function byId<T extends { id: string }>(items: readonly T[]): Map<string, T> {
@@ -70,4 +73,8 @@ export const strengthsById = byId<Trait>(strengths);
 export const flawsById = byId<Trait>(flaws);
 export const conditionsById = byId<Condition>(conditions);
 
-export type { Training, SpellTag, Tune, Trait, Condition };
+/** Every unlockable Group Bonus level, flattened out of the guide. */
+export const groupBonuses: GroupBonus[] = groupBonusGuide.bonuses;
+export const groupBonusesById = byId<GroupBonus>(groupBonuses);
+
+export type { Training, SpellTag, Tune, Trait, Condition, GroupBonus };

--- a/src/content/schema.ts
+++ b/src/content/schema.ts
@@ -422,7 +422,7 @@ export type ActiveCondition = z.infer<typeof activeConditionSchema>;
  * The live, per-session half of a character. Changes constantly. Strictly
  * disjoint from CharacterDefinition — they share only `characterId`. "New
  * scene" clears per-scene spent uses and zeroes Wyrd; "New job" clears
- * everything including Exposure.
+ * everything including Exposure, except Momentum, which carries between jobs.
  */
 export const sessionStateSchema = z.object({
   /** Links to CharacterDefinition.id. The only field the two halves share. */

--- a/src/content/schema.ts
+++ b/src/content/schema.ts
@@ -272,6 +272,48 @@ export const exposureGuideSchema = z.object({
 export type ExposureGuide = z.infer<typeof exposureGuideSchema>;
 
 /* -------------------------------------------------------------------------- */
+/* Group Bonuses (crew upgrades bought with per-player Momentum)               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * One purchasable crew upgrade. Rules: "SideQuest Group Bonuses".
+ *
+ * The rules group these under five headers, each priced "N Momentum per
+ * player", and several headers then list "level 1/2/3" variants. One entry
+ * here is one *level* — the smallest thing a crew can actually unlock.
+ *
+ * `frequency` is the same coarse enum used everywhere else and does the only
+ * work that matters: `perJob` levels become tick-off uses in the tracker,
+ * everything else is reference loadout. Nothing about the cost is resolved in
+ * code — the crew agrees at the table and each player records the result.
+ */
+export const groupBonusSchema = z.object({
+  id,
+  /** The upgrade family header, e.g. "Team Protocol". */
+  group: z.string().min(1),
+  name: z.string().min(1),
+  /** The "level N" label under its header; 1 when the family has no levels. */
+  level: z.number().int().min(1),
+  /** The per-player Momentum price printed on the family header. */
+  costPerPlayer: z.number().int(),
+  frequency: frequencyEnum.optional(),
+  text: z.string().min(1),
+  /** Optional GM-call note surfacing a ruleset gap for this level. */
+  note: z.string().optional(),
+});
+export type GroupBonus = z.infer<typeof groupBonusSchema>;
+
+/** Group Bonus reference: the purchase rule plus every unlockable level. */
+export const groupBonusGuideSchema = z.object({
+  /** The all-or-nothing condition from the section header. */
+  purchase: z.string().min(1),
+  /** GM-call note covering gaps that apply to the whole section. */
+  note: z.string().optional(),
+  bonuses: z.array(groupBonusSchema),
+});
+export type GroupBonusGuide = z.infer<typeof groupBonusGuideSchema>;
+
+/* -------------------------------------------------------------------------- */
 /* Character definition (shareable: URL fragment / JSON, changes ~once a job)  */
 /* -------------------------------------------------------------------------- */
 
@@ -331,6 +373,14 @@ export const characterDefinitionSchema = z.object({
   startingPath: pathEnum,
   /** Every node taken, across any training and either path. */
   takenNodes: z.array(nodeRefSchema),
+
+  /**
+   * Ids of unlocked Group Bonus levels. Crew-level in the fiction, but recorded
+   * per player: the table agrees on a purchase out loud and everyone marks it,
+   * exactly as promotions work. Nothing here checks that the whole crew paid.
+   * Permanent, so it lives in the definition and survives "New job".
+   */
+  groupBonuses: z.array(id).optional(),
 
   /** Wyrd-2 choices, present only once that node is taken on the Wyrd path. */
   signatureTagId: id.optional(),

--- a/src/lib/character.ts
+++ b/src/lib/character.ts
@@ -13,7 +13,7 @@ import {
   type Path,
   type StatId,
 } from '../content/schema';
-import { trainings, trainingsById } from '../content';
+import { trainings, trainingsById, groupBonuses, groupBonusesById } from '../content';
 
 export const STAT_META: { id: StatId; name: string; use: string }[] = [
   { id: 'brains', name: 'Brains', use: 'Research, analysis, tech, and planning' },
@@ -102,6 +102,36 @@ export function toggleNode(
   };
 }
 
+/* ---- group bonuses ------------------------------------------------------ */
+
+export function hasGroupBonus(def: CharacterDefinition, id: string): boolean {
+  return (def.groupBonuses ?? []).includes(id);
+}
+
+/**
+ * Mark a Group Bonus level unlocked, or undo a mis-tap. Purely a record of what
+ * the table agreed: no Momentum is spent and no prerequisite level is required,
+ * because the rules price and sequence levels ambiguously and validation here
+ * is advisory anyway.
+ */
+export function toggleGroupBonus(
+  def: CharacterDefinition,
+  id: string,
+): CharacterDefinition {
+  const current = def.groupBonuses ?? [];
+  return {
+    ...def,
+    groupBonuses: current.includes(id)
+      ? current.filter((b) => b !== id)
+      : [...current, id],
+  };
+}
+
+/** Unlocked bonuses, in catalog order rather than the order they were marked. */
+export function unlockedGroupBonuses(def: CharacterDefinition) {
+  return groupBonuses.filter((b) => hasGroupBonus(def, b.id));
+}
+
 /** Training ids the character has touched (main + any cross-trained node). */
 export function trainingsInPlay(def: CharacterDefinition): string[] {
   const ids = new Set<string>([def.mainTrainingId]);
@@ -136,7 +166,8 @@ export interface UsableAbility {
 
 /**
  * Every ability and trait the character owns, whatever its cadence: the main
- * training's specialty, taken nodes, and the chosen trope/strength/flaw. Each
+ * training's specialty, taken nodes, the chosen trope/strength/flaw, and any
+ * unlocked Group Bonus. Each
  * carries the rules `text` so the tracker can show what it does. `frequency` is
  * undefined when the source states no cadence (e.g. a passive gear note).
  */
@@ -186,6 +217,18 @@ export function characterAbilities(
         text: pick.text ?? '',
       });
     }
+  }
+
+  for (const id of def.groupBonuses ?? []) {
+    const bonus = groupBonusesById.get(id);
+    if (!bonus) continue;
+    out.push({
+      key: `group:${bonus.id}`,
+      name: bonus.name,
+      source: `Crew · ${bonus.group}`,
+      frequency: bonus.frequency,
+      text: bonus.text,
+    });
   }
 
   return out;

--- a/src/lib/serialize.test.ts
+++ b/src/lib/serialize.test.ts
@@ -186,3 +186,35 @@ describe('legacy v1 links', () => {
     expect(decodeDefinition(encodeDefinition(def))!.id).toBe(def.id);
   });
 });
+
+describe('group bonuses', () => {
+  it('round-trips unlocked bonuses', () => {
+    const def = { ...fullBuild(), groupBonuses: ['team-protocol-1', 'group-asset-2'] };
+    expect(decodeDefinition(encodeDefinition(def))?.groupBonuses).toEqual([
+      'team-protocol-1',
+      'group-asset-2',
+    ]);
+  });
+
+  it('omits the key entirely when nothing is unlocked', () => {
+    for (const def of [fullBuild(), { ...fullBuild(), groupBonuses: [] }]) {
+      const decoded = decodeDefinition(encodeDefinition(def));
+      expect(decoded?.groupBonuses).toBeUndefined();
+    }
+  });
+
+  it('still decodes a link minted before group bonuses existed', () => {
+    // v2 gained `c` additively, so an older payload simply lacks it.
+    const legacy = { ...fullBuild(), groupBonuses: ['team-protocol-1'] };
+    const encoded = encodeDefinition(legacy);
+    const wire = JSON.parse(
+      LZString.decompressFromEncodedURIComponent(encoded.slice(2)) as string,
+    );
+    delete wire.c;
+    const older =
+      '2~' + LZString.compressToEncodedURIComponent(JSON.stringify(wire));
+    const decoded = decodeDefinition(older);
+    expect(decoded?.name).toBe(legacy.name);
+    expect(decoded?.groupBonuses).toBeUndefined();
+  });
+});

--- a/src/lib/serialize.ts
+++ b/src/lib/serialize.ts
@@ -7,6 +7,8 @@
  *   Every share link minted before the compact format uses it. Decoding it is
  *   kept forever — old links must not break.
  * - **v2** (current, `2~` prefix): a compact projection of the same definition.
+ *   New optional keys may be added to v2 without a version bump: a decoder
+ *   ignores keys it does not know, and an older link simply lacks them.
  *   Short keys, node refs indexed against a link-local training list, dice as a
  *   positional string, and book-picked traits stored as bare ids and rehydrated
  *   from the content registry on read. A full build drops from ~1130 URL chars
@@ -84,6 +86,8 @@ interface WireV2 {
   k: string;
   g?: string;
   u?: string;
+  /** Unlocked Group Bonus ids, comma-joined. Absent when none are unlocked. */
+  c?: string;
   /** Dice in WIRE_STATS order, `d` prefix stripped, e.g. `"10,6,8,,12,4"`. */
   d?: string;
   r?: [WireTrait, WireTrait, WireTrait];
@@ -202,6 +206,7 @@ function toWire(def: CharacterDefinition): WireV2 {
     k: packNodes(def),
     ...(def.signatureTagId ? { g: def.signatureTagId } : {}),
     ...(def.signatureTune ? { u: def.signatureTune } : {}),
+    ...(def.groupBonuses?.length ? { c: def.groupBonuses.join(',') } : {}),
     ...(packDice(def.statDice) ? { d: packDice(def.statDice) } : {}),
     ...(traits.some((t) => t !== 0) ? { r: traits } : {}),
     ...(def.background ? { b: def.background } : {}),
@@ -225,6 +230,7 @@ function fromWire(wire: WireV2): unknown {
     takenNodes,
     ...(wire.g ? { signatureTagId: wire.g } : {}),
     ...(wire.u ? { signatureTune: wire.u } : {}),
+    ...(wire.c ? { groupBonuses: wire.c.split(',').filter(Boolean) } : {}),
     statDice: unpackDice(wire.d),
     ...Object.fromEntries(
       WIRE_TRAITS.map((slot, i) => [

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { newScene, newJob, emptySession } from './storage';
-import { emptyDefinition, usableAbilities } from './character';
+import { emptyDefinition, usableAbilities, toggleGroupBonus } from './character';
 import type { CharacterDefinition, SessionState } from '../content/schema';
 
 /**
@@ -84,5 +84,48 @@ describe('newJob', () => {
     expect(next.characterId).toBe(state.characterId);
     expect(next.exposure).toBe(0);
     expect(next).not.toBe(state);
+  });
+});
+
+describe('group bonuses across resets', () => {
+  /**
+   * The whole point of storing unlocks in the definition: a crew upgrade is
+   * bought once and kept, while its once-per-job use is spent and refreshed.
+   */
+  it('survives New job, while its per-job use is cleared', () => {
+    const def = toggleGroupBonus(
+      { ...emptyDefinition(), mainTrainingId: 'field-tinkerer' },
+      'team-protocol-1',
+    );
+    const key = usableAbilities(def).find((a) =>
+      a.key === 'group:team-protocol-1',
+    )!.key;
+
+    const spent: SessionState = {
+      ...emptySession(def.id),
+      spentUses: [key],
+    };
+
+    expect(newJob(spent).spentUses).toEqual([]);
+    expect(def.groupBonuses).toEqual(['team-protocol-1']);
+  });
+
+  it('a per-job crew use is not cleared by New scene', () => {
+    const def = toggleGroupBonus(
+      { ...emptyDefinition(), mainTrainingId: 'field-tinkerer' },
+      'team-protocol-1',
+    );
+    const spent: SessionState = {
+      ...emptySession(def.id),
+      spentUses: ['group:team-protocol-1'],
+    };
+    expect(newScene(def, spent).spentUses).toEqual(['group:team-protocol-1']);
+  });
+
+  it('a passive level takes no use slot', () => {
+    const def = toggleGroupBonus(emptyDefinition(), 'legacy-or-contact');
+    expect(
+      usableAbilities(def).some((a) => a.key === 'group:legacy-or-contact'),
+    ).toBe(false);
   });
 });

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -5,7 +5,8 @@ import type { CharacterDefinition, SessionState } from '../content/schema';
 
 /**
  * Reset semantics from CLAUDE.md: "New scene" clears per-scene uses and zeroes
- * Wyrd; "New job" clears everything including Exposure. And the two data
+ * Wyrd; "New job" clears everything including Exposure, except Momentum,
+ * which carries between jobs by GM ruling. And the two data
  * lifecycles stay disjoint — a reset must never touch the definition.
  *
  * Keys are derived from usableAbilities() rather than hard-coded so the test
@@ -80,10 +81,26 @@ describe('newJob', () => {
 
     const next = newJob(state);
 
-    expect(next).toEqual(emptySession(state.characterId));
+    expect(next).toEqual({
+      ...emptySession(state.characterId),
+      momentum: state.momentum,
+    });
     expect(next.characterId).toBe(state.characterId);
     expect(next.exposure).toBe(0);
     expect(next).not.toBe(state);
+  });
+
+  /**
+   * GM ruling: Momentum carries between jobs. It is the only counter that
+   * does, and the expensive Group Bonuses are unreachable without it —
+   * Legacy or Contact costs 5 per player against a cap of 10.
+   */
+  it('carries Momentum across the job boundary', () => {
+    const { def, perSceneKey, perJobKey } = fixture();
+    const state = seededSession(def.id, perSceneKey, perJobKey);
+
+    expect(state.momentum).toBeGreaterThan(0);
+    expect(newJob(state).momentum).toBe(state.momentum);
   });
 });
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -63,7 +63,14 @@ export function newScene(
   };
 }
 
-/** "New job": clear everything including Exposure. */
+/**
+ * "New job": clear the scene and the job — Wyrd, Exposure, conditions, and
+ * every spent use.
+ *
+ * Momentum is the one exception: it carries between jobs (GM ruling, v5.0
+ * leaves it unwritten). Zeroing it would make the expensive Group Bonuses
+ * unbuyable, since Legacy or Contact costs 5 per player against a cap of 10.
+ */
 export function newJob(state: SessionState): SessionState {
-  return emptySession(state.characterId);
+  return { ...emptySession(state.characterId), momentum: state.momentum };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -960,6 +960,118 @@ button {
   color: var(--ink);
 }
 
+/* Crew — group bonuses -------------------------------------------------- */
+.crew-owned {
+  list-style: none;
+  margin: 0 0 10px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+.crew-owned li {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 8px 4px;
+  border-bottom: 1px solid var(--line);
+}
+.crew-owned li:last-child {
+  border-bottom: none;
+}
+.crew-owned-name {
+  font-weight: 700;
+}
+.crew-owned-source {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-soft);
+}
+.crew-family {
+  margin: 12px 0;
+}
+.crew-family h3 {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 4px;
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-ink);
+}
+.crew-price {
+  margin-left: auto;
+  color: var(--ink-soft);
+  letter-spacing: 0.04em;
+}
+/* Locked levels stay legible but clearly inert — you can see what the crew
+   could save toward, the way untaken nodes are shown in the builder. */
+.crew-level {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 10px 4px;
+  border-bottom: 1px solid var(--line);
+  cursor: pointer;
+  opacity: 0.55;
+}
+.crew-level:last-child {
+  border-bottom: none;
+}
+.crew-level.afford,
+.crew-level.owned {
+  opacity: 1;
+}
+.crew-level.owned {
+  background: var(--field-2);
+}
+.crew-level input {
+  width: 22px;
+  height: 22px;
+  flex: none;
+}
+.crew-body {
+  display: flex;
+  flex-direction: column;
+}
+.crew-name {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-weight: 700;
+}
+.crew-level-no {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--ink-soft);
+}
+.crew-freq {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-style: normal;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent-ink);
+}
+.crew-text {
+  margin-top: 3px;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.crew-note {
+  margin-top: 4px;
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--warn);
+}
+
 /* Resets ---------------------------------------------------------------- */
 .resets {
   display: flex;


### PR DESCRIPTION
Adds the "SideQuest Group Bonuses" section as a Crew panel in the tracker, and fixes the Momentum reset it turned up.

Crew-level in the fiction, recorded per player: the table agrees on a purchase out loud and everyone marks it, the same way a promotion is recorded. Nothing spends Momentum or checks that the whole crew paid — the consensus already happens above table.

## Shape

One entry per *level*, since that's the smallest thing a crew can unlock. `frequency` does the only mechanical work — `perJob` levels become tick-off uses, everything else is reference loadout. No new enum values.

The two lifecycles split cleanly:

- **Unlocks are permanent** → character definition, so they survive New Job and ride the share link.
- **The once-per-job tick** → session state, via the existing `spentUses` machinery.

So `characterAbilities` gains a fourth loop and everything downstream follows for free: `perJob` levels land in Uses with checkboxes, `passive` ones in Kit, and `newScene`/`newJob` already reset by frequency.

v2 links gain an optional `c` key. Additive — no positional ordering moved, older links still decode, no version bump.

## Momentum now carries between jobs

GM ruling, and it's a real bug fix rather than a note: `newJob()` zeroed Momentum, which made the expensive bonuses unreachable — Legacy or Contact costs 5 per player against a cap of 10, so nobody could ever bank for it.

Momentum is now the one counter New job preserves; Wyrd, Exposure, conditions and every spent use still clear. The reset button and confirm dialog say so.

v5.0 left this unwritten, so the ruling is recorded in `docs/rules-v5.0.md` — **that line needs sending back to the GM.**

## GM-call notes, not resolutions

Surfaced in the UI rather than papered over in code:

- Levelled families print one per-player price with no stated per-level cost or sequencing.
- Arcane Advancement's tiers skip d6 and d10 (`d4→d8, d8→d12`).
- "Gear slot" appears exactly once in all of v5.0 — Full Gear Expansion itself — so there's no slot count to raise.
- Null Field Emitter is one use for the crew, not one each; worth flagging since each player ticks their own.

## Testing

`npm run build` passes; 47 tests green, 7 new — wire round-trip, empty-list omission, a synthesized pre-`c` payload still decoding, and the reset invariants (New Job clears the tick but keeps the unlock and the Momentum, New Scene keeps both, a `passive` level claims no use slot).

**Not visually verified.** Every changed module transforms clean off the dev server and the markup is in the output, but the page was never rendered — worth eyeballing the collapsed catalog on a phone before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174DcTUKbBSUgymcvaTQqMT
