### PR TITLE
Settle the casting roll (Q2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ dist/
 
 # TypeScript build info
 *.tsbuildinfo
+
+# Working sheet of open rules questions, shared with the GM outside the repo.
+# Local only — see CLAUDE.md.
+docs/gm-questions.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,11 @@ Keep the two kinds of edit distinct. Transcribing the GM's changes into
 decision — make those only when asked, or when something is unambiguously
 broken (a node the rules no longer define, a reference to a removed concept).
 
+Open questions for the GM live in `docs/gm-questions.md`. It is **local only,
+gitignored, and must never be committed** — it is a working sheet shared with
+the GM outside this repo. Edit it in place as answers come in (each question is
+also mirrored as a GitHub issue), but keep it out of every commit and PR.
+
 ## Non-negotiables
 
 **Do not model game mechanics.** Store rules text as prose. The only structured
@@ -93,6 +98,7 @@ definition, and loading a share link must not clobber someone's live state.
 
 ```
 docs/rules-v5.0.md      GM's ruleset, verbatim, read-only
+docs/gm-questions.md    Open questions for the GM — local only, never commit
 src/content/schema.ts   Zod schemas and inferred types
 src/content/trainings/  One file per training
 src/content/*.ts        Spell tags, tropes, strengths, flaws, conditions, wyrd

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ definition, and loading a share link must not clobber someone's live state.
 ## Layout
 
 ```
-docs/rules-v5.0.md      GM's ruleset, verbatim, read-only
+docs/rules-v5.0.md      GM's ruleset, verbatim — edited in place, see above
 docs/gm-questions.md    Open questions for the GM — local only, never commit
 src/content/schema.ts   Zod schemas and inferred types
 src/content/trainings/  One file per training

--- a/docs/rules-v5.0.md
+++ b/docs/rules-v5.0.md
@@ -1567,7 +1567,7 @@ Clear conditions with rest, support, ritual care, medical help, safehouse downti
 
 1. **Pick spell tag** (Wardmark, Glamour, etc.)
 2. **Pick scale** (S/M/L).
-3. **Roll**: Casting Stat **Magic Die** (+Skill if relevant)
+3. **Roll**: Casting Stat die **+ Magic Die** (+Skill if relevant)
 4. **TN by scale**:
 
 * **Small:** TN **9** (Standard)
@@ -1690,7 +1690,7 @@ Research Archivist module that gives a factual lead about an object/location’s
 Using a spell tag and rolling a casting stat + Magic Die.
 
 **Casting Stat**
-The stat you choose for a casting roll (whatever fits the action: Brains, Grit, etc.).
+The stat the GM calls for on a casting roll, based on what you are trying to accomplish (whatever fits the action: Brains, Grit, etc.).
 
 **Certified Domain**
 The field your **Specialist Certification** Strength applies to.

--- a/src/components/Tracker.tsx
+++ b/src/components/Tracker.tsx
@@ -11,6 +11,7 @@ import {
   wyrdTrack,
   momentumGuide,
   exposureGuide,
+  castingGuide,
   groupBonusGuide,
   groupBonuses,
 } from '../content';
@@ -260,6 +261,8 @@ export function Tracker({ def, session, onChange, onDefChange }: TrackerProps) {
 
         <p className="stat-hint cap">Tap a stat to roll its die</p>
 
+        <CastingCheat wyrd={session.wyrd} />
+
         {roll && (
           <p className="roll-readout" aria-live="polite">
             <strong>{STAT_META.find((s) => s.id === roll.statId)?.name}</strong>
@@ -498,6 +501,48 @@ function ExposureCheat({ exposure }: { exposure: number }) {
       </p>
       <p className={hit ? 'cheat-line threshold-hit' : 'cheat-line'}>
         <b>At {exposureGuide.threshold.at}:</b> {exposureGuide.threshold.text}
+      </p>
+    </details>
+  );
+}
+
+/**
+ * Casting cheat sheet. At Wyrd 4+ the escalation rule applies on its own, so
+ * the bumped TNs appear next to the printed ones and the escalation line
+ * highlights. The rule itself is always spelled out, because it also fires on a
+ * resisting target or an unstable area — a GM call the tracker can't see.
+ */
+function CastingCheat({ wyrd }: { wyrd: number }) {
+  const escalated = wyrd >= castingGuide.escalationAt;
+  return (
+    <details className="cheat">
+      <summary>Casting — what you roll</summary>
+      <p className="cheat-line">
+        <b>Roll:</b> {castingGuide.roll}
+      </p>
+      <p className="cheat-line">
+        <b>Casting stat:</b> {castingGuide.stat}
+      </p>
+      <ul className="scales">
+        {castingGuide.scales.map((scale) => (
+          <li key={scale.name} className="scale">
+            <span className="scale-name">{scale.name}</span>
+            <span className="scale-tn">
+              TN {scale.tn}
+              {escalated && <b> → {scale.escalatedTn}</b>}
+            </span>
+            <span className="scale-note">
+              {scale.difficulty}
+              {escalated && ' · escalated'}
+            </span>
+          </li>
+        ))}
+      </ul>
+      <p className={escalated ? 'cheat-line threshold-hit' : 'cheat-line'}>
+        <b>Escalation:</b> {castingGuide.escalation}
+      </p>
+      <p className="cheat-line">
+        <b>Stress:</b> {castingGuide.stress}
       </p>
     </details>
   );

--- a/src/content/casting.ts
+++ b/src/content/casting.ts
@@ -1,0 +1,24 @@
+import type { CastingGuide } from './schema';
+
+/**
+ * Casting reference. Transcribed from docs/rules-v5.0.md ("Casting with
+ * Scale"), which prints the steps, the TN per scale, and the escalation and
+ * stress rules. Reference prose only — the tracker never resolves a cast.
+ *
+ * v5.0 dropped the operator between "Casting Stat" and "Magic Die" in step 3,
+ * leaving it unclear whether a cast rolls both dice or the Magic Die alone.
+ * The GM has settled it: both dice, and the GM names the stat for the action.
+ * See https://github.com/JonasBausch/side-quest-llc/issues/6.
+ */
+export const castingGuide = {
+  roll: `Casting Stat die + Magic Die (your Wyrd Die), plus Skill if one is relevant.`,
+  stat: `The GM names the casting stat for what you're trying to accomplish, so it changes from cast to cast.`,
+  scales: [
+    { name: 'Small', tn: 9, difficulty: 'Standard', escalatedTn: '14' },
+    { name: 'Medium', tn: 12, difficulty: 'Hard', escalatedTn: '17' },
+    { name: 'Large', tn: 15, difficulty: 'Severe', escalatedTn: '20+' },
+  ],
+  escalation: `If the target is actively resisting, the area is unstable, or Wyrd is 4 or more, bump the TN up one step.`,
+  escalationAt: 4,
+  stress: `If any die shows a 1, Wyrd +1. If the die that blows up is your Magic Die, Wyrd +1.`,
+} satisfies CastingGuide;

--- a/src/content/content.test.ts
+++ b/src/content/content.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { trainings, spellTagsById, groupBonuses } from './index';
-import { trainingSchema, groupBonusGuideSchema } from './schema';
+import {
+  trainingSchema,
+  groupBonusGuideSchema,
+  castingGuideSchema,
+} from './schema';
 import { groupBonusGuide } from './group-bonuses';
+import { castingGuide } from './casting';
 
 /**
  * The "structural tests" CLAUDE.md relies on to catch silent transcription
@@ -62,5 +67,19 @@ describe('group bonuses', () => {
       if (seen === undefined) priced.set(b.group, b.costPerPlayer);
       else expect(b.costPerPlayer, `${b.group} price`).toBe(seen);
     }
+  });
+});
+
+describe('casting guide', () => {
+  it('is structurally valid', () => {
+    expect(() => castingGuideSchema.parse(castingGuide)).not.toThrow();
+  });
+
+  it('covers all three scales', () => {
+    expect(castingGuide.scales.map((s) => s.name)).toEqual([
+      'Small',
+      'Medium',
+      'Large',
+    ]);
   });
 });

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -32,6 +32,7 @@ import { conditions } from './conditions';
 import { wyrdTrack } from './wyrd';
 import { momentumGuide } from './momentum';
 import { exposureGuide } from './exposure';
+import { castingGuide } from './casting';
 import { groupBonusGuide } from './group-bonuses';
 
 /** All trainings, alphabetical by display name. */
@@ -58,6 +59,7 @@ export {
   wyrdTrack,
   momentumGuide,
   exposureGuide,
+  castingGuide,
   groupBonusGuide,
 };
 

--- a/src/content/schema.ts
+++ b/src/content/schema.ts
@@ -271,6 +271,33 @@ export const exposureGuideSchema = z.object({
 });
 export type ExposureGuide = z.infer<typeof exposureGuideSchema>;
 
+/** One scale of spell with its target number. Rules: "Casting with Scale". */
+export const castingScaleSchema = z.object({
+  name: z.string().min(1),
+  /** The printed TN, and the difficulty word next to it. */
+  tn: z.number().int(),
+  difficulty: z.string().min(1),
+  /** The TN once the escalation rule bumps it a step. Printed, not computed. */
+  escalatedTn: z.string().min(1),
+});
+export type CastingScale = z.infer<typeof castingScaleSchema>;
+
+/**
+ * Casting reference: what you roll, the TN per scale, and the two rules that
+ * push Wyrd. Prose only — nothing here resolves a cast.
+ */
+export const castingGuideSchema = z.object({
+  roll: z.string().min(1),
+  /** How the casting stat is picked. */
+  stat: z.string().min(1),
+  scales: z.array(castingScaleSchema),
+  escalation: z.string().min(1),
+  /** Wyrd value at which escalation applies on its own; lights up the line. */
+  escalationAt: z.number().int(),
+  stress: z.string().min(1),
+});
+export type CastingGuide = z.infer<typeof castingGuideSchema>;
+
 /* -------------------------------------------------------------------------- */
 /* Group Bonuses (crew upgrades bought with per-player Momentum)               */
 /* -------------------------------------------------------------------------- */

--- a/src/content/schema.ts
+++ b/src/content/schema.ts
@@ -271,7 +271,9 @@ export const exposureGuideSchema = z.object({
 });
 export type ExposureGuide = z.infer<typeof exposureGuideSchema>;
 
-/** One scale of spell with its target number. Rules: "Casting with Scale". */
+/**
+ * One scale of spell with its target number. Rules: "Casting with Scale".
+ */
 export const castingScaleSchema = z.object({
   name: z.string().min(1),
   /** The printed TN, and the difficulty word next to it. */

--- a/src/styles.css
+++ b/src/styles.css
@@ -636,6 +636,33 @@ button {
   font-size: 11px;
   color: var(--ink-soft);
 }
+.scales {
+  list-style: none;
+  margin: 6px 0;
+  padding: 0;
+  display: grid;
+  gap: 4px;
+}
+.scale {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-size: 12px;
+}
+.scale-name {
+  flex: none;
+  width: 64px;
+  font-weight: 700;
+}
+.scale-tn {
+  flex: none;
+  font-weight: 800;
+  color: var(--accent);
+}
+.scale-note {
+  font-size: 11px;
+  color: var(--ink-soft);
+}
 
 /* Tracker counters ------------------------------------------------------ */
 .row-between {


### PR DESCRIPTION
The GM answered [#6](https://github.com/JonasBausch/side-quest-llc/issues/6):

> The GM will tell you what stat to roll for what you want to accomplish, and then you roll your magic die plus the die for that stat.

So it is **both dice**, and the casting stat is a per-cast GM call rather than a fixed stat per spell tag.

## Ruleset

- Casting step 3 gets its missing operator: `Casting Stat die **+ Magic Die** (+Skill if relevant)`.
- The glossary's **Casting Stat** entry said the player chooses the stat; it is the GM's call, so it now says so.

Both are the answer written down, not a design change. Worth sending back to the GM.

## Tracker

A new **Casting — what you roll** cheat sheet in the stats card, right under the roll hint, as a collapsed `details` block matching the Momentum and Exposure sheets. It carries the roll line, who names the stat, the TN per scale (9 / 12 / 15), and the escalation and stress rules.

At Wyrd 4+ the escalation rule applies on its own, so the bumped TNs (→ 14 / 17 / 20+) appear beside the printed ones and the escalation line highlights — the same live-threshold cue the Exposure sheet uses. The escalated numbers are the ones printed in the rules, not computed. The rule stays spelled out at any Wyrd, because a resisting target or an unstable area triggers it too and the tracker can't see either.

Reference prose only: nothing resolves a cast, and the Magic Die is not derived from taken nodes.

`castingGuide` lives in `src/content/casting.ts` behind `castingGuideSchema`, registered in the content index, with structural tests alongside the training ones.

## Also

`docs/gm-questions.md` is now gitignored and documented in CLAUDE.md as local-only. It is a working sheet shared with the GM outside the repo; it has been committed and removed once already, so this stops it happening again. Q2 is marked answered in the local copy.

`npm run build` and all 49 tests pass. Not verified in a browser — the Chrome extension wasn't connected.

**Loose end for the GM, not fixed here:** the rules call it **Magic Die** in the casting steps and glossary but **Wyrd Die** in every training table. Same die, two names. The cheat sheet reads "Magic Die (your Wyrd Die)" to bridge it; worth asking which name wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174DcTUKbBSUgymcvaTQqMT