### PR TITLE
Stop CI waiting on npm's audit service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,16 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
-      - run: npm ci
+      # --no-audit skips npm's registry audit call, which is not a build gate
+      # and has stalled installs for minutes when that service is degraded.
+      - run: npm ci --no-audit --fund=false
       - run: npm run lint
       - run: npm test
       # `npm run build` is `tsc -b && vite build` — the typecheck AND the build.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,13 +18,16 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
-      - run: npm ci
+      # --no-audit skips npm's registry audit call, which is not a build gate
+      # and has stalled installs for minutes when that service is degraded.
+      - run: npm ci --no-audit --fund=false
       - run: npm run build
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
`npm ci` runs a registry security audit by default, and that service degraded this morning. It turned every install into a multi-minute stall — the one that looked like a hung pipeline on #37.

## Evidence it isn't us

Same runner image, same Node v24.20.0 and npm 11.19.0, same 203 packages, and a byte-identical npm cache key (`node-cache-Linux-x64-npm-…f32af916`) restored in under a second on every run:

| run | `npm ci` |
|---|---|
| Sep 3, 20:42 | `added 203 packages … in 4s` |
| Sep 4, 05:49 | `added 203 packages … in 2m` |
| Sep 4, 05:59 | `added 203 packages in 5m` |

Nothing in the repo changed between them — the cache key is a hash of `package-lock.json`, which none of those commits touched. In the 5m run, every step *after* the install finished in 7 seconds total: lint 2s, test 1s, build 3s.

Confirmed off GitHub's network too. From a laptop, against `registry.npmjs.org`:

- `GET /vite` (package metadata) — **3.1s**
- `POST /-/npm/v1/security/audits/quick` (the audit) — **106.9s**

## The change

- `npm ci --no-audit --fund=false` in both workflows. The audit is not a build gate: it fails nothing and blocks nothing, so all it can do here is add a network round trip that sometimes hangs. A real vulnerability signal wants a deliberate `npm audit` or Dependabot, not a stall in front of the typecheck.
- `timeout-minutes: 10` on both build jobs, so the next registry stall fails fast instead of holding a runner.

The Pages `deploy` job is left alone — it installs nothing and waits on Pages, which is allowed to be slow.

Its own CI run is the test: the install step should be back to seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174DcTUKbBSUgymcvaTQqMT