### PR TITLE
Correct the docs on lint and tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,17 +11,25 @@ running.
 ```
 npm install        # once
 npm run dev        # Vite dev server with HMR (default http://localhost:5173)
+npm run lint       # ESLint over the repo
+npm test           # Vitest, single run — npm run test:watch to leave it open
 npm run build      # tsc -b && vite build — the typecheck AND the build in one
 npm run preview    # serve the production build from dist/
 ```
 
-- **`npm run build` is the only automated gate.** There is no lint step and no
-  test runner configured — `tsc -b` inside `build` is what catches breakage, so
-  run it before you commit. To typecheck alone: `npx tsc --noEmit`.
-- **The "structural tests" referred to under Working conventions are a manual
-  review discipline** (diff each training against the PDF), not an automated
-  suite. Content correctness at runtime is enforced by the Zod schemas in
-  `src/content/schema.ts`, validated as content is imported.
+- **`lint`, `test` and `build` are the automated gates**, and
+  `.github/workflows/ci.yml` runs all three on every pull request. Run them
+  before you commit. To typecheck alone: `npx tsc --noEmit`.
+- **The structural tests under Working conventions are real tests.**
+  `src/content/content.test.ts` runs the Zod schemas against every authored
+  training — content files only `satisfies Training`, which is compile-time
+  only, so without those tests the schemas never actually execute. They catch
+  the shape failures transcription makes silently: a missing specialty, a path
+  that isn't five nodes, an empty tag list, a tag id that doesn't resolve.
+  `src/lib/` has its own suite for serialization and the reset semantics.
+- **The tests do not replace reading the diff against the PDF.** No schema can
+  see that a node's *text* is subtly wrong, and that is the failure mode this
+  content is most prone to.
 - **Deploy is automatic.** Pushing to `main` triggers `.github/workflows/deploy.yml`,
   which builds and publishes `dist/` to GitHub Pages. There is nothing to run by hand.
 

--- a/README.md
+++ b/README.md
@@ -130,14 +130,16 @@ in a browser.
 ### Other commands
 
 ```
-npm run build     # typecheck (tsc -b) AND production build into dist/
-npm run preview   # serve the built dist/ locally
-npx tsc --noEmit  # typecheck only, no build
+npm run lint       # ESLint over the repo
+npm test           # run the test suite once
+npm run test:watch # keep the tests running as you edit
+npm run build      # typecheck (tsc -b) AND production build into dist/
+npm run preview    # serve the built dist/ locally
+npx tsc --noEmit   # typecheck only, no build
 ```
 
-`npm run build` is the one automated gate — there's no separate lint step or
-test runner, so `tsc` inside the build is what catches breakage. Run it before
-you commit.
+`npm run lint`, `npm test` and `npm run build` are the automated gates, and CI
+runs all three on every pull request. Run them before you commit.
 
 ---
 


### PR DESCRIPTION
`CLAUDE.md` and `README.md` both told the reader:

> `npm run build` is the only automated gate. There is no lint step and no test runner configured…

That stopped being true when the CI gate and the Vitest suite landed. `eslint.config.js` exists, `vite.config.ts` carries a `test` block, and `.github/workflows/ci.yml` runs **lint, test and build** on every pull request. An agent reading either file would skip two of the three gates and be surprised by CI.

## Changes

- Both command lists gain `npm run lint`, `npm test`, and (README) `npm run test:watch`.
- Both "the one automated gate" paragraphs now name all three and point at CI.
- `CLAUDE.md` also described the structural tests as *"a manual review discipline… not an automated suite."* They are `src/content/content.test.ts`, and they carry more weight than that wording suggested: content files only `satisfies Training`, which is compile-time only, so those tests are the only place the Zod schemas actually execute against authored content.

The part that was right is kept and given its own bullet: no schema can see that a node's *text* is subtly wrong, so diffing each training against the PDF is still the job.

Verified locally — `npm run lint` clean, 49 tests passing across 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174DcTUKbBSUgymcvaTQqMT