### PR TITLE
Start characters with their first path node (Q3)

### DIFF
--- a/docs/rules-v5.0.md
+++ b/docs/rules-v5.0.md
@@ -54,7 +54,7 @@ Installs copper/iron hardware, chalk lines, and retrofit plates so sites don't r
 ### Path Options
 
 Once you have selected your first **Training** you decide whether to start down the Wyrd Path, giving you access to **Spell Tags**, or the Mundane Path, giving you access to tools and skills that help you do your job.
-Whichever path you choose, you get Keystone training for your **Training**.
+Whichever path you choose, you get the **Specialty** for your **Training**, plus the first node on that path (**Wyrd-1** or **Gear-1**).
 
 ---
 

--- a/src/components/Builder.tsx
+++ b/src/components/Builder.tsx
@@ -21,6 +21,9 @@ import {
   STAT_META,
   availableTagIds,
   hasNode,
+  nodeKey,
+  setStart,
+  startingNodeRef,
   toggleNode,
   trainingNodeRefs,
 } from '../lib/character';
@@ -95,7 +98,9 @@ export function Builder({ def, onChange }: BuilderProps) {
           <span>Main training</span>
           <select
             value={def.mainTrainingId}
-            onChange={(e) => update({ mainTrainingId: e.target.value })}
+            onChange={(e) =>
+              onChange(setStart(def, { mainTrainingId: e.target.value }))
+            }
           >
             {trainings.map((t) => (
               <option key={t.id} value={t.id}>
@@ -114,13 +119,18 @@ export function Builder({ def, onChange }: BuilderProps) {
                   type="radio"
                   name="startingPath"
                   checked={def.startingPath === p}
-                  onChange={() => update({ startingPath: p })}
+                  onChange={() => onChange(setStart(def, { startingPath: p }))}
                 />
                 <span>{p === 'wyrd' ? 'Wyrd' : 'Mundane'}</span>
               </label>
             ))}
           </div>
         </fieldset>
+        <p className="muted small">
+          You start play with the Specialty below plus the first node of this
+          path — Wyrd-1 or Gear-1. The Keystone is not a starting benefit; it is
+          the reward for completing all five Gear nodes.
+        </p>
 
         {mainTraining && (
           <div className="specialty">
@@ -295,10 +305,12 @@ function NodeList({
   path: Path;
   onChange: (def: CharacterDefinition) => void;
 }) {
+  const startKey = nodeKey(startingNodeRef(def));
   return (
     <div className="nodes">
       {trainingNodeRefs(trainingId, path).map(({ ref, node }) => {
         const taken = hasNode(def, ref);
+        const isStart = nodeKey(ref) === startKey;
         return (
           <button
             key={ref.index}
@@ -312,6 +324,7 @@ function NodeList({
                 {path === 'wyrd' ? 'Wyrd' : 'Gear'}-{ref.index}
               </span>
               <span className="node-name">{node.name}</span>
+              {isStart && <span className="node-start">start</span>}
               {node.cost != null && (
                 <span className="node-cost">cost {node.cost}</span>
               )}

--- a/src/lib/character.test.ts
+++ b/src/lib/character.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import {
+  emptyDefinition,
+  hasNode,
+  nodeKey,
+  setStart,
+  startingNodeRef,
+} from './character';
+import { validateDefinition } from './validate';
+import type { CharacterDefinition, NodeRef } from '../content/schema';
+
+/**
+ * Creation grants the Training's Specialty plus the first node of the chosen
+ * path — Wyrd-1 or Gear-1 (Rules: "Path Options"). Everything below is about
+ * that one free node: that a new character has it, that it follows a change of
+ * training or path, and that changing your mind at creation never eats a node
+ * that was actually earned.
+ */
+describe('the free starting node', () => {
+  it('is taken by a brand-new character, and nothing else is', () => {
+    const def = emptyDefinition();
+    expect(def.takenNodes).toEqual([startingNodeRef(def)]);
+  });
+
+  it('follows a change of starting path', () => {
+    const def = emptyDefinition();
+    const next = setStart(def, { startingPath: 'wyrd' });
+
+    expect(next.startingPath).toBe('wyrd');
+    expect(next.takenNodes).toEqual([
+      { trainingId: def.mainTrainingId, path: 'wyrd', index: 1 },
+    ]);
+  });
+
+  it('follows a change of main training', () => {
+    const def = emptyDefinition();
+    const next = setStart(def, { mainTrainingId: 'negotiator' });
+
+    expect(hasNode(next, startingNodeRef(next))).toBe(true);
+    expect(hasNode(next, startingNodeRef(def))).toBe(false);
+  });
+
+  it('leaves earned and cross-trained nodes alone', () => {
+    const earned: NodeRef = {
+      trainingId: 'field-tinkerer',
+      path: 'mundane',
+      index: 3,
+    };
+    const crossed: NodeRef = {
+      trainingId: 'negotiator',
+      path: 'wyrd',
+      index: 1,
+    };
+    const def: CharacterDefinition = {
+      ...emptyDefinition(),
+      mainTrainingId: 'field-tinkerer',
+      startingPath: 'mundane',
+      takenNodes: [
+        { trainingId: 'field-tinkerer', path: 'mundane', index: 1 },
+        earned,
+        crossed,
+      ],
+    };
+
+    const next = setStart(def, { startingPath: 'wyrd' });
+
+    expect(next.takenNodes).toContainEqual(earned);
+    expect(next.takenNodes).toContainEqual(crossed);
+  });
+
+  it('does not duplicate a node the character already had', () => {
+    const def: CharacterDefinition = {
+      ...emptyDefinition(),
+      mainTrainingId: 'field-tinkerer',
+      startingPath: 'mundane',
+      takenNodes: [
+        { trainingId: 'field-tinkerer', path: 'mundane', index: 1 },
+        { trainingId: 'field-tinkerer', path: 'wyrd', index: 1 },
+      ],
+    };
+
+    const next = setStart(def, { startingPath: 'wyrd' });
+    const keys = next.takenNodes.map(nodeKey);
+
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(next.takenNodes).toHaveLength(1);
+  });
+
+  it('is only advised, never enforced', () => {
+    const def: CharacterDefinition = {
+      ...emptyDefinition(),
+      name: 'Jules',
+      takenNodes: [],
+    };
+
+    // The build stands; the player is only told what creation would have given.
+    expect(validateDefinition(def)).toContainEqual(
+      expect.stringContaining('Gear-1'),
+    );
+  });
+});

--- a/src/lib/character.ts
+++ b/src/lib/character.ts
@@ -46,15 +46,55 @@ function newCharacterId(): string {
 }
 
 export function emptyDefinition(): CharacterDefinition {
+  const mainTrainingId = trainings[0].id;
+  const startingPath: Path = 'mundane';
   return {
     id: newCharacterId(),
     rulesVersion: CURRENT_RULES_VERSION,
     name: '',
-    mainTrainingId: trainings[0].id,
-    startingPath: 'mundane',
-    takenNodes: [],
+    mainTrainingId,
+    startingPath,
+    takenNodes: [startingNodeRef({ mainTrainingId, startingPath })],
     statDice: {},
   };
+}
+
+/**
+ * The node a character has before earning anything: index 1 of their starting
+ * path in their main training. Rules: "Path Options" — creation grants the
+ * Training's Specialty plus either Wyrd-1 or Gear-1. The Keystone is not part
+ * of that; it is the reward for completing all five Gear nodes.
+ */
+export function startingNodeRef(def: {
+  mainTrainingId: string;
+  startingPath: Path;
+}): NodeRef {
+  return {
+    trainingId: def.mainTrainingId,
+    path: def.startingPath,
+    index: 1,
+  };
+}
+
+/**
+ * Change the main training or the starting path, carrying the free starting
+ * node across with it. Only the old starting node is dropped — cross-trained
+ * nodes and anything earned by promotion are left exactly as they are, since
+ * those were paid for and this swap is a creation-time correction.
+ */
+export function setStart(
+  def: CharacterDefinition,
+  patch: { mainTrainingId?: string; startingPath?: Path },
+): CharacterDefinition {
+  const next = { ...def, ...patch };
+  const oldKey = nodeKey(startingNodeRef(def));
+  const newRef = startingNodeRef(next);
+  const newKey = nodeKey(newRef);
+  if (oldKey === newKey) return next;
+  const kept = next.takenNodes.filter(
+    (n) => nodeKey(n) !== oldKey && nodeKey(n) !== newKey,
+  );
+  return { ...next, takenNodes: [newRef, ...kept] };
 }
 
 /* ---- node references ---------------------------------------------------- */

--- a/src/lib/validate.ts
+++ b/src/lib/validate.ts
@@ -4,7 +4,13 @@
  */
 import type { CharacterDefinition } from '../content/schema';
 import { trainingsById } from '../content';
-import { DICE, STAT_META, availableTagIds } from './character';
+import {
+  DICE,
+  STAT_META,
+  availableTagIds,
+  hasNode,
+  startingNodeRef,
+} from './character';
 
 export function validateDefinition(def: CharacterDefinition): string[] {
   const warnings: string[] = [];
@@ -28,6 +34,16 @@ export function validateDefinition(def: CharacterDefinition): string[] {
   const dupes = assigned.filter((d, i) => assigned.indexOf(d) !== i);
   if (dupes.length) {
     warnings.push(`Same die used more than once: ${[...new Set(dupes)].join(', ')}.`);
+  }
+
+  // Creation grants the Specialty plus the first node of the starting path
+  // (Rules: "Path Options"). Advisory like everything else here — a table that
+  // rules otherwise just ignores it.
+  if (!hasNode(def, startingNodeRef(def))) {
+    const label = def.startingPath === 'wyrd' ? 'Wyrd-1' : 'Gear-1';
+    warnings.push(
+      `Characters start with the first node of their starting path (${label}); it is not taken.`,
+    );
   }
 
   // Signature choices only make sense with the Wyrd-2 node and a valid tag.

--- a/src/styles.css
+++ b/src/styles.css
@@ -432,6 +432,20 @@ button {
   font-size: 11px;
   color: var(--ink-soft);
 }
+.node-start {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  border: 1px solid var(--ink-soft);
+  color: var(--ink-soft);
+  padding: 1px 5px;
+  border-radius: 2px;
+}
+.node.taken .node-start {
+  border-color: currentColor;
+  color: inherit;
+}
 .node-text {
   font-size: 13px;
   color: var(--ink-soft);


### PR DESCRIPTION
The GM answered [#7](https://github.com/JonasBausch/side-quest-llc/issues/7):

> You start with your Training Specialty plus either the first Wyrd 1 or Gear 1.

So the glossary was right and the creation line was wrong. A Keystone is the reward for completing all five Gear nodes; it is not a starting benefit.

## Ruleset

The creation line said:

> Whichever path you choose, you get Keystone training for your **Training**.

"Keystone training" there meant the grounding a Training gives you, not *a Keystone* — which is what made it read as contradicting the glossary. It now names the two things creation actually grants:

> Whichever path you choose, you get the **Specialty** for your **Training**, plus the first node on that path (**Wyrd-1** or **Gear-1**).

The glossary entry is untouched.

## Builder

New characters started with nothing ticked — a placeholder from when this was ambiguous. Now:

- A new character has the first node of their starting path, and it's badged `start` in the node list.
- Changing training or starting path carries that free node across. At creation this is a correction, not a promotion, so only the *old* starting node moves: earned nodes and cross-trained ones stay put, and a node the character already had is never duplicated.
- A line under the path picker says what you start with, and what the Keystone actually is.
- Advisory, never enforced: untick the node and you get a warning, not a block.

The Keystone stays unmodelled. That was already true; it is now true on purpose.

New `src/lib/character.test.ts` covers the swap in both directions, the earned/cross-trained cases, the no-duplicate case, and the advisory. 55 tests green, lint clean, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174DcTUKbBSUgymcvaTQqMT