### PR TITLE
Write down that Conditions stack (Q5)

### DIFF
--- a/docs/rules-v5.0.md
+++ b/docs/rules-v5.0.md
@@ -1558,6 +1558,8 @@ Conditions apply −1 ongoing to relevant rolls until cleared.
 * **Marked** (the phenomenon “knows you”)- **Flight/Charm**
 * **Strained** (magic overload)- **Grit/Brains**
 
+**Conditions stack.** Two Conditions that hit the same stat apply **−2** to it: a character who is both **Shaken** and **Winded** rolls **Fight** at −2.
+
 Clear conditions with rest, support, ritual care, medical help, safehouse downtime, or a successful stabilizing scene.
 \page
 

--- a/src/components/Tracker.tsx
+++ b/src/components/Tracker.tsx
@@ -235,7 +235,7 @@ export function Tracker({ def, session, onChange, onDefChange }: TrackerProps) {
       {/* Conditions + stat cross-reference --------------------------- */}
       <section className="card">
         <h2>
-          Conditions <span className="cap">−1 to relevant rolls</span>
+          Conditions <span className="cap">−1 each · same stat stacks</span>
         </h2>
         <div className="conditions">
           {conditions.map((cond) => {

--- a/src/content/schema.ts
+++ b/src/content/schema.ts
@@ -437,9 +437,9 @@ export type CharacterDefinition = z.infer<typeof characterDefinitionSchema>;
 /* -------------------------------------------------------------------------- */
 
 /**
- * One active condition instance. The rules leave open whether two conditions on
- * the same stat stack, so duplicates are permitted here and the UI surfaces it
- * as a GM call rather than resolving it.
+ * One active condition instance. Conditions that hit the same stat stack, so
+ * the tracker adds up every active condition on a stat and shows the total with
+ * the names behind it. The total is a reminder, not something applied to a roll.
  */
 export const activeConditionSchema = z.object({
   id: conditionIdEnum,


### PR DESCRIPTION
The GM answered [#9](https://github.com/JonasBausch/side-quest-llc/issues/9):

> Conditions that are on the same stat stack

So Shaken + Winded is **−2** to Fight, not −1.

**The app was already right** — the tracker counts every active Condition on a stat and shows the total with the names behind it. No behaviour changes here. What changes is that two places still described this as an open question, and the rulebook never covered it at all.

## Ruleset

The Conditions section never said what happens when two Conditions hit the same stat, and it comes up as soon as Wyrd starts climbing. It now does:

> **Conditions stack.** Two Conditions that hit the same stat apply **−2** to it: a character who is both **Shaken** and **Winded** rolls **Fight** at −2.

Shaken + Winded because it's the overlap a table hits first — the only stat both touch is Fight.

## Tracker

- The Conditions header said `−1 to relevant rolls`, which reads as a flat −1 however many you're carrying. Now `−1 each · same stat stacks`.
- `ActiveCondition`'s doc comment claimed the rules leave stacking open and that the UI surfaces it as a GM call. It doesn't surface it as a GM call, and the rules no longer leave it open.

The stacked total stays what it always was: a reminder next to the die, never applied to a roll.

Build, lint and 55 tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174DcTUKbBSUgymcvaTQqMT