### PR TITLE
Record the settled Exposure and Momentum limits (Q6)

### DIFF
--- a/docs/rules-v5.0.md
+++ b/docs/rules-v5.0.md
@@ -1491,6 +1491,8 @@ This ensures escalation even when the team is competent, and it makes failure me
 
 **At 3 failures:** the scene continues, but a consequence hits (authorities arrive, footage spreads, site gets restricted, new complication clock).
 
+**Exposure does not reset.** It is an open-ended tally: the consequence at 3 fires, and the number keeps climbing from there. Clearing Exposure is the only thing that brings it down.
+
 #### Wyrd 6 Reality Surge
 
 When Wyrd hits 6:

--- a/src/components/Tracker.tsx
+++ b/src/components/Tracker.tsx
@@ -25,7 +25,8 @@ import {
 } from '../lib/character';
 import { newJob, newScene } from '../lib/storage';
 
-const MAX_MOMENTUM = 10;
+// The cap is content, not a component constant — it comes from the rules.
+const MAX_MOMENTUM = momentumGuide.cap;
 
 interface TrackerProps {
   def: CharacterDefinition;
@@ -207,7 +208,11 @@ export function Tracker({ def, session, onChange, onDefChange }: TrackerProps) {
             <Counter
               label="Momentum"
               value={session.momentum}
-              note={session.momentum >= MAX_MOMENTUM ? 'at cap (10)' : undefined}
+              note={
+                session.momentum >= MAX_MOMENTUM
+                  ? `at cap (${MAX_MOMENTUM})`
+                  : undefined
+              }
               onDec={() =>
                 patch({ momentum: Math.max(0, session.momentum - 1) })
               }
@@ -502,6 +507,7 @@ function ExposureCheat({ exposure }: { exposure: number }) {
       <p className={hit ? 'cheat-line threshold-hit' : 'cheat-line'}>
         <b>At {exposureGuide.threshold.at}:</b> {exposureGuide.threshold.text}
       </p>
+      <p className="cheat-meta">{exposureGuide.tally}</p>
     </details>
   );
 }

--- a/src/content/content.test.ts
+++ b/src/content/content.test.ts
@@ -4,9 +4,13 @@ import {
   trainingSchema,
   groupBonusGuideSchema,
   castingGuideSchema,
+  exposureGuideSchema,
+  momentumGuideSchema,
 } from './schema';
 import { groupBonusGuide } from './group-bonuses';
 import { castingGuide } from './casting';
+import { exposureGuide } from './exposure';
+import { momentumGuide } from './momentum';
 
 /**
  * The "structural tests" CLAUDE.md relies on to catch silent transcription
@@ -81,5 +85,19 @@ describe('casting guide', () => {
       'Medium',
       'Large',
     ]);
+  });
+});
+
+describe('resource guides', () => {
+  it('are structurally valid', () => {
+    expect(() => exposureGuideSchema.parse(exposureGuide)).not.toThrow();
+    expect(() => momentumGuideSchema.parse(momentumGuide)).not.toThrow();
+  });
+
+  // Both confirmed by the GM: Momentum is capped, Exposure is not.
+  it('cap Momentum at 10 and leave Exposure open-ended', () => {
+    expect(momentumGuide.cap).toBe(10);
+    expect(exposureGuide.threshold.at).toBe(3);
+    expect(exposureGuide.tally).toMatch(/does not reset/i);
   });
 });

--- a/src/content/exposure.ts
+++ b/src/content/exposure.ts
@@ -2,9 +2,12 @@ import type { ExposureGuide } from './schema';
 
 /**
  * Exposure reference. Transcribed from docs/rules-v5.0.md ("Exposure").
- * Reference prose only. Note: whether Exposure is a 0–3 clock that resets or an
- * open counter is unresolved in v5.0 — see https://github.com/JonasBausch/side-quest-llc/issues/13.
- * The tracker treats it as an open counter and surfaces the 3-mark consequence here.
+ * Reference prose only.
+ *
+ * v5.0 left it unclear whether Exposure was a 0–3 clock that empties when it
+ * fires or a tally that keeps climbing. The GM has settled it as an open-ended
+ * tally, which is what the tracker already did — so the counter has a floor of
+ * zero and no ceiling. See https://github.com/JonasBausch/side-quest-llc/issues/13.
  */
 export const exposureGuide = {
   mark: `Witnesses/cameras catch it, alarms/damage, obvious magic, cops/security escalate, evidence left behind.`,
@@ -13,4 +16,5 @@ export const exposureGuide = {
     at: 3,
     text: `The scene continues, but a consequence hits (authorities arrive, footage spreads, site gets restricted, new complication clock).`,
   },
+  tally: `Exposure does not reset when the consequence fires — it keeps climbing. Clearing is the only thing that brings it down.`,
 } satisfies ExposureGuide;

--- a/src/content/schema.ts
+++ b/src/content/schema.ts
@@ -268,6 +268,8 @@ export const exposureGuideSchema = z.object({
     at: z.number().int(),
     text: z.string().min(1),
   }),
+  /** Whether the count resets at the threshold or keeps going. */
+  tally: z.string().min(1),
 });
 export type ExposureGuide = z.infer<typeof exposureGuideSchema>;
 


### PR DESCRIPTION
The GM answered [#13](https://github.com/JonasBausch/side-quest-llc/issues/13):

> 10 is still the Momentum cap. Exposure is an open-ended tally.

**Both placeholders were right**, so neither counter changes behaviour: Momentum still stops at 10, Exposure still has a floor of zero and no ceiling. What changes is that the ruleset never said either thing out loud, and the code still described the Exposure question as open.

## Ruleset

Nothing in v5.0 said what happens to Exposure after the consequence at 3 fires, so it read equally well as a clock that empties and refills or as a tally that keeps climbing. Now:

> **Exposure does not reset.** It is an open-ended tally: the consequence at 3 fires, and the number keeps climbing from there. Clearing Exposure is the only thing that brings it down.

## App

- `exposureGuide` gains that line, and the Exposure cheat sheet shows it — the question was most likely to come up mid-scene, which is exactly where the sheet is.
- Its file comment no longer describes this as unresolved.
- The Momentum cap was a component constant in `Tracker.tsx` that happened to equal `momentumGuide.cap`, with a second hardcoded `10` inside the "at cap" string. It reads the guide now. Content is data; the component shouldn't know the number.
- `exposureGuide` and `momentumGuide` were the only content collections with no schema test. They have one, plus an assertion pinning the two limits the GM just confirmed — so a future edit that quietly caps Exposure or moves the Momentum ceiling fails a test instead of a session.

Build, lint and 57 tests green.

## Worth a look separately

The glossary's **Exposure Clock** entry — *"a clock tracking public visibility/response (e.g. '4 successes before 3 failures')"* — describes something different from the running Exposure tally. It's one of the scene clock structures listed alongside Containment, Chase and Extraction. Two different things sharing a name is most of why this was ambiguous. I haven't touched it; it probably wants its own question to the GM about splitting the names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174DcTUKbBSUgymcvaTQqMT