### PR TITLE
Name where Signature tags come from (Q7)

### DIFF
--- a/docs/rules-v5.0.md
+++ b/docs/rules-v5.0.md
@@ -1310,8 +1310,10 @@ After completing a job successfully, Sidequest LLC allows you to take an additio
 
 ---
 
-This training can be from one of the paths in your main tranining, or you can cross-train into another training, as long as you meet the prerequisites for it.
+This training can be from one of the paths in your main training, or you can cross-train into another training, as long as you meet the prerequisites for it.
 The only limitation is that you cannot take the training specialty for any training that is not your main one.
+
+Cross-training onto another training's Wyrd Path gives you that training's **spell tags** as well, and your **Signature** may be any tag you have access to, from either training.
 
 ---
 Example: Ethel is a **Research Archivist** and just completed a job with her team She currently has Gear 1 and 2 on the Mundane Path in **Research Archivist**. Ethel could either take Wyrd 1 or Gear 3 in **Research Archivist** or she could choose to take Wyrd 1 or Gear 1 from any other training module. Ethel chooses to take **Crowd Liason** Gear 1.

--- a/src/components/Builder.tsx
+++ b/src/components/Builder.tsx
@@ -24,6 +24,7 @@ import {
   nodeKey,
   setStart,
   startingNodeRef,
+  tagSourceTrainingIds,
   toggleNode,
   trainingNodeRefs,
 } from '../lib/character';
@@ -48,6 +49,9 @@ export function Builder({ def, onChange }: BuilderProps) {
   const warnings = useMemo(() => validateDefinition(def), [def]);
   const mainTraining = trainingsById.get(def.mainTrainingId);
   const tagIds = availableTagIds(def);
+  const tagSources = tagSourceTrainingIds(def).map(
+    (id) => trainingsById.get(id)?.name ?? id,
+  );
   const hasSignatureNode = def.takenNodes.some(
     (n) => n.path === 'wyrd' && n.index === 2,
   );
@@ -202,6 +206,11 @@ export function Builder({ def, onChange }: BuilderProps) {
         {hasSignatureNode && (
           <div className="signature">
             <h3>Signature</h3>
+            <p className="muted small">
+              {tagSources.length > 1
+                ? `Tags from ${tagSources.join(' + ')} — cross-training opens both lists. Only the Specialty is locked to your main training.`
+                : `Tags from ${tagSources[0] ?? 'your training'}. Cross-train a Wyrd node and that training's tags open up too.`}
+            </p>
             <label className="field">
               <span>Spell tag</span>
               <select

--- a/src/lib/character.test.ts
+++ b/src/lib/character.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import {
+  availableTagIds,
   emptyDefinition,
   hasNode,
   nodeKey,
   setStart,
   startingNodeRef,
+  tagSourceTrainingIds,
 } from './character';
 import { validateDefinition } from './validate';
+import { trainingsById } from '../content';
 import type { CharacterDefinition, NodeRef } from '../content/schema';
 
 /**
@@ -97,5 +100,50 @@ describe('the free starting node', () => {
     expect(validateDefinition(def)).toContainEqual(
       expect.stringContaining('Gear-1'),
     );
+  });
+});
+
+/**
+ * A cross-trained character picks their Signature from either training's tags
+ * (Rules: "Getting a Promotion"). The Specialty is the only thing locked to the
+ * main training, so tags are a union, never a filter.
+ */
+describe('signature tag access', () => {
+  const main = 'field-tinkerer';
+  const other = 'sensor-operator';
+
+  function withNode(path: 'wyrd' | 'mundane') {
+    return {
+      ...emptyDefinition(),
+      mainTrainingId: main,
+      startingPath: 'mundane' as const,
+      takenNodes: [{ trainingId: other, path, index: 1 }],
+    };
+  }
+
+  it('offers the main training on its own', () => {
+    const def = { ...emptyDefinition(), mainTrainingId: main };
+    expect(tagSourceTrainingIds(def)).toEqual([main]);
+  });
+
+  it('adds the training of a cross-trained Wyrd node', () => {
+    expect(tagSourceTrainingIds(withNode('wyrd')).sort()).toEqual(
+      [main, other].sort(),
+    );
+  });
+
+  it('does not add a training entered on the Gear side alone', () => {
+    expect(tagSourceTrainingIds(withNode('mundane'))).toEqual([main]);
+  });
+
+  it('unions both tag lists rather than filtering to the main training', () => {
+    const def = withNode('wyrd');
+    const tags = availableTagIds(def);
+
+    for (const id of [main, other]) {
+      for (const tag of trainingsById.get(id)!.availableTagIds) {
+        expect(tags).toContain(tag);
+      }
+    }
   });
 });

--- a/src/lib/character.ts
+++ b/src/lib/character.ts
@@ -180,17 +180,27 @@ export function trainingsInPlay(def: CharacterDefinition): string[] {
 }
 
 /**
- * Spell tag ids the character can pick a Signature from: the union of available
- * tags across the main training and any training in which a Wyrd node is taken.
+ * Trainings whose spell tags the character can reach: the main training, plus
+ * any training they have cross-trained a Wyrd node into. Tags come with the
+ * Wyrd Path, so a training entered on the Gear side alone contributes none.
+ */
+export function tagSourceTrainingIds(def: CharacterDefinition): string[] {
+  const ids = new Set<string>([def.mainTrainingId]);
+  for (const n of def.takenNodes) if (n.path === 'wyrd') ids.add(n.trainingId);
+  return [...ids].filter((id) => trainingsById.has(id));
+}
+
+/**
+ * Spell tag ids the character can pick a Signature from: the union across every
+ * training they can reach tags in. Rules: "Getting a Promotion" — a Signature
+ * may be any tag you have access to, from either training. The Specialty is the
+ * only thing locked to the main training.
  */
 export function availableTagIds(def: CharacterDefinition): string[] {
   const out = new Set<string>();
-  const add = (id: string) => {
-    const t = trainingsById.get(id);
-    if (t) t.availableTagIds.forEach((tag) => out.add(tag));
-  };
-  add(def.mainTrainingId);
-  for (const n of def.takenNodes) if (n.path === 'wyrd') add(n.trainingId);
+  for (const id of tagSourceTrainingIds(def)) {
+    trainingsById.get(id)?.availableTagIds.forEach((tag) => out.add(tag));
+  }
   return [...out];
 }
 


### PR DESCRIPTION
The GM answered [#12](https://github.com/JonasBausch/side-quest-llc/issues/12):

> A cross-trained character can pick a Signature from either training's spell tags, the only thing that is locked behind their main training is their Training Specialty.

**The generous reading was right**, so `availableTagIds` doesn't change behaviour — it already unioned the main training with any cross-trained Wyrd node.

## Ruleset

The promotion section said what cross-training *withholds*:

> The only limitation is that you cannot take the training specialty for any training that is not your main one.

…but never what it grants. It now says both, in the same place:

> Cross-training onto another training's Wyrd Path gives you that training's **spell tags** as well, and your **Signature** may be any tag you have access to, from either training.

Also fixes `tranining` on the line above it.

## Builder

- The training half of the union is worth a name of its own, so it's `tagSourceTrainingIds`, and `availableTagIds` is the union over it. One place decides which trainings you can reach tags in.
- The Signature picker now says where its list came from — *"Tags from Field Tinkerer + Sensor Operator — cross-training opens both lists. Only the Specialty is locked to your main training."* A character with one training gets the nudge instead: cross-train a Wyrd node and a second list opens.

Tests cover the union, the main training standing alone, and the Gear-side case below.

Build, lint and 59 tests green.

## One judgement call to confirm

We read spell tags as coming with the **Wyrd Path** specifically, so cross-training into a training's **Gear** side alone opens none of its tags. That's what the code has always done and there's now a test pinning it — but it's an inference from "Wyrd-1 gives you the die and the tags", not something the GM was asked. Flagged in the question doc for the next round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174DcTUKbBSUgymcvaTQqMT