### PR TITLE
Give Unshakable Calm a per-scene tick-box (Q10)

### DIFF
--- a/src/content/content.test.ts
+++ b/src/content/content.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { trainings, spellTagsById, groupBonuses } from './index';
+import { trainings, spellTagsById, groupBonuses, strengthsById } from './index';
 import {
   trainingSchema,
   groupBonusGuideSchema,
@@ -99,5 +99,14 @@ describe('resource guides', () => {
     expect(momentumGuide.cap).toBe(10);
     expect(exposureGuide.threshold.at).toBe(3);
     expect(exposureGuide.tally).toMatch(/does not reset/i);
+  });
+});
+
+describe('trait cadences', () => {
+  // GM ruling: Unshakable Calm gets a tick-box even though it fires on its own.
+  // Book traits ride in a share link as an id and are rebuilt from content, so
+  // this cadence reaches characters built before the ruling.
+  it('makes Unshakable Calm a per-scene use', () => {
+    expect(strengthsById.get('unshakable-calm')?.frequency).toBe('perScene');
   });
 });

--- a/src/content/strengths.ts
+++ b/src/content/strengths.ts
@@ -4,6 +4,13 @@ import type { Trait } from './schema';
  * Strengths. Transcribed from docs/rules-v5.0.md ("Strengths"). Homebrew is
  * allowed at the character level. `frequency` follows each entry's own
  * "1/scene" or "1/job" wording; passive/situational ones carry no cadence.
+ *
+ * A cadence counts even when the entry doesn't spell it out and the player
+ * never chooses to spend it: Unshakable Calm covers "the scene's first" scare,
+ * which is once per scene however automatically it fires. What the tick-box
+ * records is whether it has already happened, and that is worth knowing.
+ * Entries bounded to something other than a scene or a job — a clock, an NPC,
+ * a day — still carry no cadence, because the enum has no such unit.
  */
 export const strengths = [
   {
@@ -84,6 +91,7 @@ export const strengths = [
     id: 'unshakable-calm',
     name: 'Unshakable Calm',
     text: `When Wyrd hits 4+, you don't take Shaken from the scene's first scare/shift.`,
+    frequency: 'perScene',
   },
   {
     id: 'vehicle-mastery',


### PR DESCRIPTION
The GM answered [#30](https://github.com/JonasBausch/side-quest-llc/issues/30):

> Give it a tick-box

## The change

One line: Unshakable Calm gains `frequency: 'perScene'`. That's the whole mechanism — the tracker builds its use list from cadences, so the Strength now appears under **Uses → Per scene** beside Jaded Survivor, and `New scene` clears it.

The reasoning worth recording, and now in the file comment: a cadence counts **even when the entry doesn't spell it out and the player never chooses to spend it**. "The scene's first scare/shift" is once per scene however automatically it fires. What the tick-box records is whether that first scare has already happened — the one thing a table can't otherwise see.

**No ruleset change.** The rules already say "the scene's first"; this was only ever about how the app classifies it.

## Existing characters get it for free

A book-picked trait rides in a share link as its **id**, and `unpackTrait` rebuilds name, text and frequency from current content. So characters built before this ruling pick up the tick-box without anyone re-picking anything. That path is already covered by `serialize.test.ts` ("stores a book-picked trait by id and resolves it from content").

Added one test pinning the cadence, so a future edit can't quietly drop the ruling.

## Three others say "first" and are deliberately untouched

| Trait | Wording | Actual cadence |
|---|---|---|
| Vehicle Mastery | "your first success in any chase/drive/pilot clock" | once per **clock** |
| Reads People Instantly | "on first meeting someone" | once per **person** |
| Not a People Person | "your first social roll with a new NPC" | once per **person** |

None is bounded to a scene — a scene can hold more than one clock, and any number of NPCs. The cadence enum is per scene / per job / passive / counter, with no unit for "per clock" or "per NPC", and inventing one for three entries looks worse than leaving them as notes. Flagged in the question doc in case the GM disagrees.

Build, lint and 62 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174DcTUKbBSUgymcvaTQqMT