### PR TITLE
Settle Gear-2 as the Forensics Kit (Q13)

### DIFF
--- a/docs/rules-v5.0.md
+++ b/docs/rules-v5.0.md
@@ -225,7 +225,7 @@ Set **Exposure to 0 for that zone** and your report holds.
 | Wyrd Path                                         | Mundane Path                        |
 | ------------------------------------------------- | ----------------------------------- |
 | **Wyrd-1:** D4 Wyrd Die (Small Spells)            | **Gear-1:** Glamour Wash            |
-| **Wyrd-2:** Pick a signature spell tag            | **Gear-2:** Trace Kit               |
+| **Wyrd-2:** Pick a signature spell tag            | **Gear-2:** Forensics Kit           |
 | **Wyrd-3:** D8 Wyrd Die (Small and Medium Spells) | **Gear-3:** Neutralizer             |
 | **Wyrd-4:** Residue Economy                       | **Gear-4:** Certification Stamp     |
 | **Wyrd-5:** D12 Wyrd Die (All Spell Sizes)        | **Gear-5:** Hazmat Seal             |

--- a/src/content/trainings/cleanup-specialist.ts
+++ b/src/content/trainings/cleanup-specialist.ts
@@ -4,12 +4,11 @@ import type { Training } from '../schema';
  * Cleanup Specialist — "Professional vibes janitor."
  * Transcribed verbatim from docs/rules-v5.0.md ("Cleanup Specialist").
  *
- * Naming conflict, flagged: the leveling-track table calls Gear-2 "Trace Kit",
- * but the Mundane Path Options describe it under the heading "Forensics Kit".
- * The table is the canonical node list (tables win), so the node name follows
- * the table and the text is the Forensics Kit prose. Wyrd-4 is Residue Economy,
- * inline. Neutralizer's rules text is truncated in the source ("choose one:"
- * with a single option) and is transcribed as printed.
+ * Gear-2 went by two names in v5.0 — "Trace Kit" in the leveling table and
+ * "Forensics Kit" over the prose. The GM has settled it as one item called the
+ * Forensics Kit, and the table has been corrected to match. Wyrd-4 is Residue
+ * Economy, inline. Neutralizer's rules text is truncated in the source ("choose
+ * one:" with a single option) and is transcribed as printed.
  */
 export const cleanupSpecialist = {
   id: 'cleanup-specialist',
@@ -53,7 +52,7 @@ export const cleanupSpecialist = {
       frequency: 'perScene',
     },
     {
-      name: `Trace Kit`,
+      name: `Forensics Kit`,
       text: `Collect a sample that becomes a leverage asset (intel, contact, crafting input, ward ingredient). If you use it later to support a cover story, it can justify clearing Exposure (GM call).`,
       cost: 1,
     },


### PR DESCRIPTION
The GM answered [#14](https://github.com/JonasBausch/side-quest-llc/issues/14):

> It is one gear item, and should be named Forensics Kit

So Cleanup Specialist was never short a gear step — one item had picked up two names.

## The change

- `docs/rules-v5.0.md:228` — the table row becomes **Gear-2: Forensics Kit**, matching the description already printed under it at `:244`. Nothing else about the entry moves.
- `cleanup-specialist.ts` — the node takes the same name. Its file comment recorded the conflict and the "tables win" tie-break used to pick `Trace Kit`; it now records the resolution instead.

## Notes

**No links break.** A node travels in a share link as its position in a path — training, path, index — never as a name. Anyone holding a Cleanup Specialist with Gear-2 taken sees the new name on open.

The other flag in that file's comment stays: **Neutralizer**'s "choose one:" with a single option is still truncated as printed, pending [#16](https://github.com/JonasBausch/side-quest-llc/issues/16).

Build, lint and 61 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174DcTUKbBSUgymcvaTQqMT