### PR TITLE
Put Sensor Operator's free gear first (Q14)

### DIFF
--- a/docs/rules-v5.0.md
+++ b/docs/rules-v5.0.md
@@ -995,8 +995,8 @@ Once/job, freeze a moment and ask **three SENSE reads** about the same subject.
 #### Leveling Paths
 | Wyrd Path                                         | Mundane Path                     |
 | ------------------------------------------------- | -------------------------------- |
-| **Wyrd-1:** D4 Wyrd Die (Small Spells)            | **Gear-1:** EM/Sigil Sweep       |
-| **Wyrd-2:** Pick a signature spell tag            | **Gear-2:** Thermal Polaroids       |
+| **Wyrd-1:** D4 Wyrd Die (Small Spells)            | **Gear-1:** Thermal Polaroids       |
+| **Wyrd-2:** Pick a signature spell tag            | **Gear-2:** EM/Sigil Sweep          |
 | **Wyrd-3:** D8 Wyrd Die (Small and Medium Spells) | **Gear-3:** Ring-Light Projector |
 | **Wyrd-4:** Echo Recording                        | **Gear-4:** Pattern Library      |
 | **Wyrd-5:** D12 Wyrd Die (All Spell Sizes)        | **Gear-5:** Signal Stitcher      |

--- a/src/content/content.test.ts
+++ b/src/content/content.test.ts
@@ -31,6 +31,13 @@ describe('trainings', () => {
     },
   );
 
+  // The pattern that caught Sensor Operator's swapped Gear-1/Gear-2: the free
+  // item opens the Mundane Path in every training. A costed Gear-1 means two
+  // entries have been transcribed in the wrong order.
+  it.each(trainings)('$name opens its Mundane Path with the free gear', (training) => {
+    expect(training.mundaneNodes[0].cost ?? 0).toBe(0);
+  });
+
   it.each(trainings)(
     '$name references only spell tags that resolve',
     (training) => {

--- a/src/content/trainings/sensor-operator.ts
+++ b/src/content/trainings/sensor-operator.ts
@@ -4,10 +4,11 @@ import type { Training } from '../schema';
  * Sensor Operator — "We have it on Polaroid."
  * Transcribed verbatim from docs/rules-v5.0.md ("Sensor Operator").
  *
- * Cost/order conflict, flagged: unlike every other training, the "—" (no-cost)
- * gear is NOT Gear-1 here. The leveling table orders Gear-1 EM/Sigil Sweep (1),
- * Gear-2 Thermal Polaroids (—), … so node order follows the table while each
- * item keeps its own printed cost tier.
+ * v5.0's leveling table put the costed EM/Sigil Sweep at Gear-1 and the free
+ * Thermal Polaroids at Gear-2, the only training where the "—" gear was not
+ * first. The GM confirms that was a slip: the two are swapped, which also makes
+ * the table agree with the Mundane Path Options prose, where Thermal Polaroids
+ * was always printed first.
  *
  * Also: this section's Echo Recording (Wyrd-4) omits the "Cost: Echos are
  * sticky" line that Artifact Handler and Research Archivist include. Transcribed
@@ -50,15 +51,15 @@ export const sensorOperator = {
   ],
   mundaneNodes: [
     {
+      name: `Thermal Polaroids`,
+      text: `Once/scene, ask one SENSE question with gear. Answer arrives as an image artifact.`,
+      frequency: 'perScene',
+    },
+    {
       name: `EM/Sigil Sweep`,
       text: `On entering a scene, name what you're scanning for (ridden object / thin place / trigger / anchor). Learn where it is OR what it is not (GM answers concretely). Limit: 1/scene.`,
       frequency: 'perScene',
       cost: 1,
-    },
-    {
-      name: `Thermal Polaroids`,
-      text: `Once/scene, ask one SENSE question with gear. Answer arrives as an image artifact.`,
-      frequency: 'perScene',
     },
     {
       name: `Ring-Light Projector`,


### PR DESCRIPTION
The GM answered [#15](https://github.com/JonasBausch/side-quest-llc/issues/15):

> Thermal Polaroids should be the first item and EM/Sigil Sweep should be the second.

## The change

Sensor Operator was the only training whose leveling table opened the Mundane Path with a **costed** item — EM/Sigil Sweep (1) at Gear-1, free Thermal Polaroids (—) at Gear-2. The two swap.

Worth noting: **the prose was already right.** The Mundane Path Options section below the table (`:1009`) has always printed Thermal Polaroids first, then EM/Sigil Sweep. Only the table disagreed, which is what made this look like a transcription slip rather than a design choice — and it was.

## New structural test

All ten trainings now open their Mundane Path with the free item, so that's pinned:

```ts
it.each(trainings)('$name opens its Mundane Path with the free gear', (training) => {
  expect(training.mundaneNodes[0].cost ?? 0).toBe(0);
});
```

This is the pattern that made the outlier visible in the first place. A costed Gear-1 is a cheap signal that two entries went in out of order.

Build, lint and 72 tests green.

## One thing that can't be fixed in code

A share link records a gear step as its **position** — training, path, index — not by name. So a Sensor Operator who had taken **only Gear-1** was holding EM/Sigil Sweep and now holds Thermal Polaroids. The position stayed; the item under it changed. Anyone with both gear steps is unaffected.

There's no way to detect or migrate this: the link carries no per-node identity, and the `rulesVersion` banner won't fire because the ruleset is still 5.0 and is edited in place by design. It's flagged in the question doc — if a Sensor Operator at the table is mid-job with exactly one gear step, that's worth thirty seconds of checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174DcTUKbBSUgymcvaTQqMT